### PR TITLE
chore: oculta OAuth da interface (v1)

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,4 +1,3 @@
-import { LoginSocial } from './login.js';
 import { ListaDeProdutos } from './listaProdutos.js';
 import { UI } from './ui.js';
 import { Sugestoes } from './sugestoes.js';
@@ -74,7 +73,6 @@ const produtosPrincipais = [
 window.addEventListener('DOMContentLoaded', () => {
   lucide.createIcons();
 
-  new LoginSocial();
 
   const lista = new ListaDeProdutos();
   const ui = new UI(lista);

--- a/index.html
+++ b/index.html
@@ -8,8 +8,6 @@
     <link rel="manifest" href="manifest.json">
     <script src="https://unpkg.com/lucide@latest"></script>
     <link rel="stylesheet" href="assets/css/style.css">
-    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
-    <script src="https://kit.fontawesome.com/e49f1d70d5.js" crossorigin="anonymous"></script>
 
   </head>
   <body class="bg-gray-50 dark:bg-gray-900 min-h-screen flex flex-col items-center py-10 px-4 text-gray-800 dark:text-gray-100 pb-32 transition-colors duration-300 overflow-hidden">
@@ -123,27 +121,6 @@
             style="display: none;">
       Instalar App
     </button>
-
-    <!-- Botão de login Social -->
-    <div class="fixed top-4 right-16 z-50 flex items-center gap-3 bg-gray-100 dark:bg-gray-800 px-4 py-2 rounded-2xl shadow-lg border border-gray-200 dark:border-gray-700">
-      <!-- Botão Login Google -->
-      <button id="btnLoginGoogle" 
-        class="flex items-center gap-2 px-4 py-2 rounded-xl bg-gradient-to-r from-red-500 to-yellow-500 text-white font-medium shadow-md hover:opacity-90 transition">
-        <i class="fa-brands fa-google text-lg"></i>
-        Entrar
-      </button>
-
-      <!-- Status -->
-      <p id="status" 
-        class="px-4 py-2 text-sm rounded-xl bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-200 shadow-inner min-w-[100px] text-center">
-      </p>
-
-      <!-- Botão Logout -->
-      <button id="btnLogout" 
-        class="flex items-center justify-center px-3 py-2 rounded-xl bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600 transition shadow-md">
-        <i data-lucide="log-out" class="w-5 h-5"></i>
-      </button>
-    </div>
 
     <!-- Botão de tema -->
     <button id="btn-tema" class="fixed top-6 right-4 p-2 rounded-full shadow bg-white dark:bg-gray-800 text-gray-800 dark:text-white transition-colors">


### PR DESCRIPTION
### Motivação
- A primeira versão não deve expor o fluxo de OAuth incompleto nem carregar dependências externas desnecessárias, simplificando a interface para o MVP.

### Descrição
- Remove a importação e a inicialização de `LoginSocial` em `assets/js/main.js` para desativar o boot do login social.
- Remove o bloco visual de autenticação (Entrar / Status / Logout) de `index.html` para que o recurso não apareça ao usuário.
- Remove os scripts CDN de Supabase e Font Awesome de `index.html` já que o OAuth ficará fora da primeira versão.
- Mantém o código de login em `assets/js/login.js` intacto para reativação futura sem alterações estruturais.

### Testing
- Verificação por busca com `rg "LoginSocial|btnLoginGoogle|btnLogout|id=\"status\""` confirmou que as referências à UI de login foram removidas da página principal e residem apenas no arquivo de implementação de login.
- Iniciou um servidor estático com `python -m http.server 4173` para inspecionar a aplicação sem OAuth carregado com sucesso.
- Tentativa de captura de tela via Playwright falhou devido a um crash do Chromium no ambiente de execução, portanto a verificação visual automática não pôde ser completada.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996523185f48324b52fab8a96db46eb)