### PR TITLE
Ocultar botão "Instalar" quando PWA instalada e abrir app em modo standalone com "Abrir Calculadora"

### DIFF
--- a/assets/js/landing.js
+++ b/assets/js/landing.js
@@ -6,11 +6,7 @@ window.addEventListener('DOMContentLoaded', () => {
   lucide.createIcons();
 
   const openButton = document.getElementById('openCalculatorBtn');
-
-  const installer = new PWAInstaller('installBtnLanding', 'inline-flex', (isInstalled) => {
-    if (!openButton) return;
-    openButton.dataset.installed = String(isInstalled);
-  });
+  const installer = new PWAInstaller('installBtnLanding', 'inline-flex');
 
   if (openButton) {
     openButton.addEventListener('click', (event) => {
@@ -19,7 +15,11 @@ window.addEventListener('DOMContentLoaded', () => {
       const targetUrl = openButton.getAttribute('href') || 'app.html';
 
       if (installer.isInstalled()) {
-        window.location.assign(targetUrl);
+        // Tenta disparar captura de link do PWA instalado (quando suportado pelo navegador).
+        const popup = window.open(targetUrl, '_blank', 'noopener');
+        if (!popup) {
+          window.location.href = targetUrl;
+        }
         return;
       }
 

--- a/assets/js/landing.js
+++ b/assets/js/landing.js
@@ -1,6 +1,7 @@
 import './pwaRegister.js';
 import { PWAInstaller } from './pwaInstaller.js';
 import { ThemeToggle } from './theme.js';
+import { Toast } from './toast.js';
 
 window.addEventListener('DOMContentLoaded', () => {
   lucide.createIcons();
@@ -11,10 +12,13 @@ window.addEventListener('DOMContentLoaded', () => {
   if (openButton) {
     openButton.addEventListener('click', () => {
       if (installer.isInstalled()) {
+        const path = window.location.pathname;
+        const newPath = path.substring(0, path.lastIndexOf("/"));
+        const appUrl = window.location.origin + newPath;
         // Quando instalado, tenta seguir o fluxo de abertura do app instalado.
-        const popup = window.open(window.location.origin, '_blank', 'noopener');
+        const popup = window.open(appUrl + '/app.html', '_blank', 'noopener');
         if (!popup) {
-          window.location.href = window.location.origin;
+          Toast.mostrar('A calculadora foi aberta!', 'sucesso');
         }
         return;
       }

--- a/assets/js/landing.js
+++ b/assets/js/landing.js
@@ -4,6 +4,28 @@ import { ThemeToggle } from './theme.js';
 
 window.addEventListener('DOMContentLoaded', () => {
   lucide.createIcons();
-  new PWAInstaller('installBtnLanding', 'inline-flex');
+
+  const openButton = document.getElementById('openCalculatorBtn');
+
+  const installer = new PWAInstaller('installBtnLanding', 'inline-flex', (isInstalled) => {
+    if (!openButton) return;
+    openButton.dataset.installed = String(isInstalled);
+  });
+
+  if (openButton) {
+    openButton.addEventListener('click', (event) => {
+      event.preventDefault();
+
+      const targetUrl = openButton.getAttribute('href') || 'app.html';
+
+      if (installer.isInstalled()) {
+        window.location.assign(targetUrl);
+        return;
+      }
+
+      window.location.href = targetUrl;
+    });
+  }
+
   ThemeToggle.init();
 });

--- a/assets/js/landing.js
+++ b/assets/js/landing.js
@@ -9,21 +9,18 @@ window.addEventListener('DOMContentLoaded', () => {
   const installer = new PWAInstaller('installBtnLanding', 'inline-flex');
 
   if (openButton) {
-    openButton.addEventListener('click', (event) => {
-      event.preventDefault();
-
-      const targetUrl = openButton.getAttribute('href') || 'app.html';
-
+    openButton.addEventListener('click', () => {
       if (installer.isInstalled()) {
-        // Tenta disparar captura de link do PWA instalado (quando suportado pelo navegador).
-        const popup = window.open(targetUrl, '_blank', 'noopener');
+        // Quando instalado, tenta seguir o fluxo de abertura do app instalado.
+        const popup = window.open(window.location.origin, '_blank', 'noopener');
         if (!popup) {
-          window.location.href = targetUrl;
+          window.location.href = window.location.origin;
         }
         return;
       }
 
-      window.location.href = targetUrl;
+      // Sem instalação, abre diretamente a calculadora web.
+      window.location.href = 'app.html';
     });
   }
 

--- a/assets/js/pwaInstaller.js
+++ b/assets/js/pwaInstaller.js
@@ -18,8 +18,8 @@ export class PWAInstaller {
       e.preventDefault();
 
       if (this.installed) {
-        this.button.style.display = 'none';
-        return;
+        // Se o evento apareceu, o app está instalável novamente (evita estado antigo no localStorage).
+        this.setInstalledState(false);
       }
 
       this.deferredPrompt = e;

--- a/assets/js/pwaInstaller.js
+++ b/assets/js/pwaInstaller.js
@@ -1,14 +1,27 @@
 // assets/js/pwaInstaller.js
 export class PWAInstaller {
-  constructor(buttonId, displayMode = 'block') {
+  static STORAGE_KEY = 'pwa-installed';
+
+  constructor(buttonId, displayMode = 'block', onInstallStateChange = null) {
     this.button = document.getElementById(buttonId);
     this.deferredPrompt = null;
     this.displayMode = displayMode;
+    this.onInstallStateChange = onInstallStateChange;
+    this.installed = this.isStandaloneMode() || localStorage.getItem(PWAInstaller.STORAGE_KEY) === 'true';
 
     if (!this.button) return;
 
+    this.button.style.display = 'none';
+    this.notifyInstallStateChange();
+
     window.addEventListener('beforeinstallprompt', (e) => {
       e.preventDefault();
+
+      if (this.installed) {
+        this.button.style.display = 'none';
+        return;
+      }
+
       this.deferredPrompt = e;
       this.button.style.display = this.displayMode;
       this.button.addEventListener('click', () => this.instalar(), { once: true });
@@ -16,9 +29,30 @@ export class PWAInstaller {
 
     window.addEventListener('appinstalled', () => {
       console.log('📲 PWA instalada com sucesso!');
+      this.setInstalledState(true);
       this.button.style.display = 'none';
       this.deferredPrompt = null;
     });
+  }
+
+  isStandaloneMode() {
+    return window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true;
+  }
+
+  isInstalled() {
+    return this.installed;
+  }
+
+  notifyInstallStateChange() {
+    if (typeof this.onInstallStateChange === 'function') {
+      this.onInstallStateChange(this.installed);
+    }
+  }
+
+  setInstalledState(value) {
+    this.installed = value;
+    localStorage.setItem(PWAInstaller.STORAGE_KEY, String(value));
+    this.notifyInstallStateChange();
   }
 
   async instalar() {
@@ -27,6 +61,7 @@ export class PWAInstaller {
     this.deferredPrompt.prompt();
     const escolha = await this.deferredPrompt.userChoice;
     if (escolha.outcome !== 'dismissed') {
+      this.setInstalledState(true);
       this.button.style.display = 'none';
       this.deferredPrompt = null;
     }

--- a/index.html
+++ b/index.html
@@ -22,9 +22,9 @@
           <i data-lucide="download" class="w-4 h-4"></i>
           Instalar
         </button>
-        <a href="app.html" class="inline-flex items-center gap-2 bg-green-600 hover:bg-green-700 text-white font-semibold px-5 py-2.5 rounded-xl transition-all shadow-sm">
+        <a id="openCalculatorBtn" href="app.html" class="inline-flex items-center gap-2 bg-green-600 hover:bg-green-700 text-white font-semibold px-5 py-2.5 rounded-xl transition-all shadow-sm">
           <i data-lucide="arrow-right" class="w-4 h-4"></i>
-          Abrir calculadora
+          Abrir Calculadora
         </a>
       </div>
     </header>

--- a/index.html
+++ b/index.html
@@ -22,10 +22,10 @@
           <i data-lucide="download" class="w-4 h-4"></i>
           Instalar
         </button>
-        <a id="openCalculatorBtn" href="app.html" class="inline-flex items-center gap-2 bg-green-600 hover:bg-green-700 text-white font-semibold px-5 py-2.5 rounded-xl transition-all shadow-sm">
+        <button id="openCalculatorBtn" type="button" class="inline-flex items-center gap-2 bg-green-600 hover:bg-green-700 text-white font-semibold px-5 py-2.5 rounded-xl transition-all shadow-sm">
           <i data-lucide="arrow-right" class="w-4 h-4"></i>
           Abrir Calculadora
-        </a>
+        </button>
       </div>
     </header>
 

--- a/index.html
+++ b/index.html
@@ -120,6 +120,9 @@
       <i data-lucide="moon" id="icone-tema"></i>
     </button>
 
+    <!-- Toast Container -->
+    <div id="toast-container" class="fixed top-4 right-4 space-y-3 z-50 max-w-sm w-full "></div>
+
     <script type="module" src="./assets/js/landing.js"></script>
   </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,21 +1,22 @@
 {
-    "name": "Calculadora de Compras",
-    "short_name": "Compras",
-    "start_url": "./index.html",
-    "display": "standalone",
-    "background_color": "#ffffff",
-    "theme_color": "#10b981",
-    "icons": [
-      {
-        "src": "assets/icon/icon-192.png",
-        "sizes": "192x192",
-        "type": "image/png"
-      },
-      {
-        "src": "assets/icon/icon-512.png",
-        "sizes": "512x512",
-        "type": "image/png"
-      }
-    ]
-  }
-  
+  "name": "Calculadora de Compras",
+  "short_name": "Compras",
+  "id": "./app.html",
+  "start_url": "./app.html",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#10b981",
+  "icons": [
+    {
+      "src": "assets/icon/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "assets/icon/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Melhorar a experiência da landing evitando mostrar o botão de instalação quando o app já está instalado.  
- Garantir que o botão `Abrir Calculadora` tente abrir o app no modo standalone quando estiver instalado, e abra normalmente no navegador caso contrário.

### Description
- Atualiza `assets/js/pwaInstaller.js` para persistir o estado de instalação em `localStorage` (`pwa-installed`), detectar `display-mode: standalone`, e expor métodos/ callbacks: `isInstalled()`, `setInstalledState()` e um `onInstallStateChange` opcional.  
- Ajusta o comportamento do evento `beforeinstallprompt` e `appinstalled` para ocultar corretamente o botão de instalação quando o app já estiver instalado.  
- Atualiza `assets/js/landing.js` para obter o botão `#openCalculatorBtn`, instanciar `PWAInstaller` com um callback que propaga o estado de instalação e interceptar o clique em `Abrir Calculadora` para navegar via `window.location.assign()` quando `isInstalled()` for `true` (tentando abrir o app standalone) ou usar `window.location.href` caso contrário.  
- Altera `index.html` para adicionar `id=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998ddeb47d883249a4a333a70dce682)