### PR TITLE
Ajusta OAuth e reformula UI de login no app

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ Para habilitar armazenamento de perfil (id, email, nome, avatar e provider), exe
 
 Esse script cria a tabela `public.profiles`, trigger de criação automática no `auth.users` e políticas RLS para cada usuário acessar apenas o próprio perfil.
 
+### Solução para erro OAuth `Database error saving new user`
+
+Se aparecer na URL algo como:
+`error=server_error&error_description=Database+error+saving+new+user`,
+normalmente é falha na trigger de `auth.users`.
+
+1. Abra o **SQL Editor** no Supabase.
+2. Execute novamente o arquivo `supabase_profiles_schema.sql` atualizado.
+3. Esse script agora protege a trigger com `exception when others`, evitando bloquear o cadastro/login OAuth quando houver falha de sincronização de perfil.
+
 ## 📦 Versão
 
 **1.0.0**

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ Uma calculadora simples e prática para usar durante suas compras no mercado. Id
 - 💾 Salvamento automático das listas
 - 📊 Estatísticas de gastos
 
+
+## 🔐 Supabase (perfil de usuário)
+
+Para habilitar armazenamento de perfil (id, email, nome, avatar e provider), execute o script abaixo no SQL Editor do Supabase:
+
+- `supabase_profiles_schema.sql`
+
+Esse script cria a tabela `public.profiles`, trigger de criação automática no `auth.users` e políticas RLS para cada usuário acessar apenas o próprio perfil.
+
 ## 📦 Versão
 
 **1.0.0**

--- a/app.html
+++ b/app.html
@@ -3,112 +3,121 @@
   <head>
     <meta charset="UTF-8" />
     <title>Calculadora de Compras</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="assets/icon/favicon.ico" type="image/x-icon">
-    <link rel="manifest" href="manifest.json">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="assets/icon/favicon.ico" type="image/x-icon" />
+    <link rel="manifest" href="manifest.json" />
     <script src="https://unpkg.com/lucide@latest"></script>
-    <link rel="stylesheet" href="assets/css/style.css">
+    <link rel="stylesheet" href="assets/css/style.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
-    <script src="https://kit.fontawesome.com/e49f1d70d5.js" crossorigin="anonymous"></script>
-
+    <script
+      src="https://kit.fontawesome.com/e49f1d70d5.js"
+      crossorigin="anonymous"
+    ></script>
   </head>
-  <body class="bg-gray-50 dark:bg-gray-900 min-h-screen flex flex-col items-center py-10 px-4 text-gray-800 dark:text-gray-100 pb-32 transition-colors duration-300 overflow-hidden">
 
-    <!-- BLOCO PAI -->
-  <div class="w-full max-w-md absolute top-6 left-4">
+  <body
+    class="bg-gray-50 dark:bg-gray-900 h-[100dvh] overflow-hidden flex flex-col items-center px-4 text-gray-800 dark:text-gray-100 transition-colors duration-300"
+  >
+    <!-- BLOCO PAI (Título no canto superior esquerdo) -->
+    <div class="w-full max-w-md absolute top-6 left-4">
+      <h1
+        class="flex gap-2 text-3xl font-bold mb-8 text-gray-800 dark:text-gray-100 justify-start text-left"
+      >
+        <i data-lucide="shopping-cart" class="w-8 h-8 text-green-600"></i>
 
-    <!-- Título -->
-    <h1 class="flex gap-2 text-3xl font-bold mb-8
-               text-gray-800 dark:text-gray-100
-               justify-start text-left">
-
-      <i data-lucide="shopping-cart"
-         class="w-8 h-8 text-green-600">
-      </i>
-
-      <!-- some no mobile -->
-      <span class="hidden sm:inline">
-        <!--Calculadora de Compras-->
-      </span>
-
-    </h1>
-
-  </div>
-
-    <!-- Formulário -->
-    <div class="w-full max-w-md bg-white dark:bg-gray-800 rounded-2xl shadow p-6 space-y-5 mt-15">
-  
-  <!-- Container dos dois campos -->
-  <div class="grid grid-cols-3 gap-4">
-    
-    <!-- Nome do Produto (2/3) -->
-    <div class="col-span-2 relative">
-      <label for="nome-produto" class="block text-sm font-medium mb-1">
-        Nome do Produto
-      </label>
-      <input 
-        type="text" 
-        id="nome-produto"
-        class="w-full border-gray-300 dark:border-gray-700 rounded-lg shadow-sm focus:ring-green-500 focus:border-green-500 px-4 py-2 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100" 
-        placeholder="Ex: Maçã"
-      />
-
-      <!-- Lista de sugestões -->
-      <ul 
-        id="sugestoes" 
-        class="absolute w-full bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded-md mt-1 max-h-40 overflow-y-auto hidden text-gray-900 dark:text-gray-100">
-      </ul>
+        <!-- some no mobile -->
+        <span class="hidden sm:inline">
+          <!-- Calculadora de Compras -->
+        </span>
+      </h1>
     </div>
 
-    <!-- Valor (1/3) -->
-    <div>
-      <label for="valor-produto" class="block text-sm font-medium mb-1">
-        Valor (R$)
-      </label>
-      <input 
-        type="text" 
-        id="valor-produto"
-        class="w-full border-gray-300 dark:border-gray-700 rounded-lg shadow-sm focus:ring-green-500 focus:border-green-500 px-4 py-2 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100" 
-        placeholder="2.50"
-      />
-    </div>
+    <!-- MIolo responsivo: formulário + lista (lista é a única que rola) -->
+    <main class="w-full max-w-md flex flex-col flex-1 min-h-0 mt-16">
+      <!-- Formulário -->
+      <div class="w-full bg-white dark:bg-gray-800 rounded-2xl shadow p-6 space-y-5">
+        <!-- Container dos dois campos -->
+        <div class="grid grid-cols-3 gap-4">
+          <!-- Nome do Produto (2/3) -->
+          <div class="col-span-2 relative">
+            <label for="nome-produto" class="block text-sm font-medium mb-1">
+              Nome do Produto
+            </label>
+            <input
+              type="text"
+              id="nome-produto"
+              class="w-full border-gray-300 dark:border-gray-700 rounded-lg shadow-sm focus:ring-green-500 focus:border-green-500 px-4 py-2 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+              placeholder="Ex: Maçã"
+            />
 
-  </div>
+            <!-- Lista de sugestões -->
+            <ul
+              id="sugestoes"
+              class="absolute w-full bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded-md mt-1 max-h-40 overflow-y-auto hidden text-gray-900 dark:text-gray-100"
+            ></ul>
+          </div>
 
-  <!-- Botão -->
-  <button id="btn-adicionar"
-    class="w-full bg-green-600 hover:bg-green-700 transition-all text-white font-semibold py-3 rounded-lg flex items-center justify-center gap-2">
-    <i data-lucide="plus-circle" class="w-5 h-5"></i>
-    Adicionar Produto
-  </button>
+          <!-- Valor (1/3) -->
+          <div>
+            <label for="valor-produto" class="block text-sm font-medium mb-1">
+              Valor (R$)
+            </label>
+            <input
+              type="text"
+              id="valor-produto"
+              class="w-full border-gray-300 dark:border-gray-700 rounded-lg shadow-sm focus:ring-green-500 focus:border-green-500 px-4 py-2 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+              placeholder="2.50"
+            />
+          </div>
+        </div>
 
-</div>
+        <!-- Botão -->
+        <button
+          id="btn-adicionar"
+          class="w-full bg-green-600 hover:bg-green-700 transition-all text-white font-semibold py-3 rounded-lg flex items-center justify-center gap-2"
+        >
+          <i data-lucide="plus-circle" class="w-5 h-5"></i>
+          Adicionar Produto
+        </button>
+      </div>
 
-    <!-- Lista de Produtos -->
-   <div class="mt-10 w-full max-w-md">
-  <h2 class="text-2xl font-semibold mb-4">
-    Produtos Adicionados
-  </h2>
+      <!-- Lista de Produtos (ÚNICO scroll da página) -->
+      <section class="mt-6 flex flex-col flex-1 min-h-0">
+        <h2 class="text-2xl font-semibold mb-4">Produtos Adicionados</h2>
 
-  <ul id="produtos-list"
-      class="space-y-4 max-h-130 overflow-y-auto pr-2 scrollbar-hide pb-50">
-  </ul>
-</div>
+        <ul
+          id="produtos-list"
+          class="space-y-4 flex-1 min-h-0 overflow-y-auto pr-2 scrollbar-hide
+                 pb-[calc(120px+env(safe-area-inset-bottom))]"
+        ></ul>
+      </section>
+    </main>
 
     <!-- Painel fixo inferior -->
-    <div class="fixed bottom-0 left-0 w-full bg-white dark:bg-gray-800 border-t border-gray-300 dark:border-gray-700 shadow-md z-50">
-      <div class="max-w-4xl mx-auto px-4 py-4 flex flex-col sm:flex-row items-center justify-between gap-4">
+    <div
+      class="fixed bottom-0 left-0 w-full bg-white dark:bg-gray-800 border-t border-gray-300 dark:border-gray-700 shadow-md z-50"
+    >
+      <div
+        class="max-w-4xl mx-auto px-4 py-4 flex flex-col sm:flex-row items-center justify-between gap-4"
+      >
         <div class="flex items-center gap-3">
           <i data-lucide="package" class="w-6 h-6 text-blue-600"></i>
           <div>
-            <p class="text-sm text-gray-500 dark:text-gray-400" hidden>Quantidade de Itens</p>
-            <p id="contagem-itens" class="text-lg font-bold text-blue-600">0 item(s)</p>
+            <p class="text-sm text-gray-500 dark:text-gray-400" hidden>
+              Quantidade de Itens
+            </p>
+            <p id="contagem-itens" class="text-lg font-bold text-blue-600">
+              0 item(s)
+            </p>
           </div>
         </div>
+
         <div class="flex items-center gap-3">
           <i data-lucide="dollar-sign" class="w-6 h-6 text-green-600"></i>
           <div>
-            <p class="text-sm text-gray-500 dark:text-gray-400" hidden>Valor Total</p>
+            <p class="text-sm text-gray-500 dark:text-gray-400" hidden>
+              Valor Total
+            </p>
             <p id="total" class="text-lg font-bold text-green-600">R$ 0,00</p>
           </div>
         </div>
@@ -116,36 +125,69 @@
     </div>
 
     <!-- Toast Container -->
-    <div id="toast-container" class="fixed top-4 right-4 space-y-3 z-50 max-w-sm w-full"></div>
+    <div
+      id="toast-container"
+      class="fixed top-4 right-4 space-y-3 z-50 max-w-sm w-full"
+    ></div>
 
-    <button id="installBtn"
-            class="fixed bottom-2 left-1/2 transform -translate-x-1/2 bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded-lg shadow-lg transition duration-300 z-50"
-            style="display: none;">
+    <button
+      id="installBtn"
+      class="fixed bottom-2 left-1/2 transform -translate-x-1/2 bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded-lg shadow-lg transition duration-300 z-50"
+      style="display: none"
+    >
       Instalar App
     </button>
 
     <!-- Ações de autenticação -->
     <div class="fixed top-6 right-16 z-50">
-      <button id="btnAbrirLoginModal"
-              class="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-green-600 hover:bg-green-700 text-white font-semibold shadow-md transition">
+      <button
+        id="btnAbrirLoginModal"
+        class="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-green-600 hover:bg-green-700 text-white font-semibold shadow-md transition"
+      >
         <i data-lucide="log-in" class="w-4 h-4"></i>
         Login
       </button>
 
       <div id="userMenuContainer" class="hidden relative">
-        <button id="btnAvatar" type="button" aria-expanded="false"
-                class="w-10 h-10 rounded-full overflow-hidden bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-100 shadow-md flex items-center justify-center">
-          <img id="avatarImage" alt="Avatar do usuário" class="w-full h-full object-cover hidden" />
+        <button
+          id="btnAvatar"
+          type="button"
+          aria-expanded="false"
+          class="w-10 h-10 rounded-full overflow-hidden bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-100 shadow-md flex items-center justify-center"
+        >
+          <img
+            id="avatarImage"
+            alt="Avatar do usuário"
+            class="w-full h-full object-cover hidden"
+          />
           <span id="avatarFallback" class="inline-flex items-center justify-center"></span>
         </button>
 
-        <div id="userDropdown" class="hidden absolute right-0 mt-2 w-60 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-xl p-2">
+        <div
+          id="userDropdown"
+          class="hidden absolute right-0 mt-2 w-60 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-xl p-2"
+        >
           <div class="px-3 py-2 border-b border-gray-200 dark:border-gray-700 mb-2">
             <p id="nomeUsuario" class="text-sm font-semibold">Não autenticado</p>
-            <p id="emailUsuario" class="text-xs text-gray-500 dark:text-gray-300">Faça login para continuar</p>
+            <p
+              id="emailUsuario"
+              class="text-xs text-gray-500 dark:text-gray-300"
+            >
+              Faça login para continuar
+            </p>
           </div>
-          <button id="btnEditarPerfil" class="w-full text-left px-3 py-2 text-sm rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition">Editar perfil</button>
-          <button id="btnLogout" class="w-full text-left px-3 py-2 text-sm rounded-lg text-red-600 hover:bg-red-50 dark:hover:bg-red-950/40 transition">Sair</button>
+          <button
+            id="btnEditarPerfil"
+            class="w-full text-left px-3 py-2 text-sm rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition"
+          >
+            Editar perfil
+          </button>
+          <button
+            id="btnLogout"
+            class="w-full text-left px-3 py-2 text-sm rounded-lg text-red-600 hover:bg-red-50 dark:hover:bg-red-950/40 transition"
+          >
+            Sair
+          </button>
         </div>
       </div>
     </div>
@@ -153,36 +195,73 @@
     <div id="loginModal" class="hidden fixed inset-0 z-[70]">
       <div id="loginModalOverlay" class="absolute inset-0 bg-black/50"></div>
       <div class="absolute inset-0 flex items-center justify-center p-4">
-        <div class="w-full max-w-sm bg-white dark:bg-gray-800 rounded-2xl shadow-2xl border border-gray-200 dark:border-gray-700 p-6 space-y-4 relative">
-          <button id="btnFecharLoginModal" type="button" class="absolute top-3 right-3 p-1 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700">
+        <div
+          class="w-full max-w-sm bg-white dark:bg-gray-800 rounded-2xl shadow-2xl border border-gray-200 dark:border-gray-700 p-6 space-y-4 relative"
+        >
+          <button
+            id="btnFecharLoginModal"
+            type="button"
+            class="absolute top-3 right-3 p-1 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700"
+          >
             <i data-lucide="x" class="w-5 h-5"></i>
           </button>
 
           <div>
             <h3 class="text-xl font-bold">Entrar na calculadora</h3>
-            <p class="text-sm text-gray-500 dark:text-gray-300">Use seu email/senha ou continue com Google.</p>
+            <p class="text-sm text-gray-500 dark:text-gray-300">
+              Use seu email/senha ou continue com Google.
+            </p>
           </div>
 
           <form id="loginForm" class="space-y-3">
             <div>
               <label for="emailLogin" class="block text-sm mb-1">Email</label>
-              <input id="emailLogin" type="email" required class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2" placeholder="voce@email.com" />
+              <input
+                id="emailLogin"
+                type="email"
+                required
+                class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2"
+                placeholder="voce@email.com"
+              />
             </div>
             <div>
               <label for="senhaLogin" class="block text-sm mb-1">Senha</label>
-              <input id="senhaLogin" type="password" required class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2" placeholder="••••••••" />
+              <input
+                id="senhaLogin"
+                type="password"
+                required
+                class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2"
+                placeholder="••••••••"
+              />
             </div>
-            <button type="submit" class="w-full bg-green-600 hover:bg-green-700 text-white font-semibold py-2.5 rounded-lg transition">Logar</button>
+            <button
+              type="submit"
+              class="w-full bg-green-600 hover:bg-green-700 text-white font-semibold py-2.5 rounded-lg transition"
+            >
+              Logar
+            </button>
           </form>
 
-          <button id="btnCriarConta" type="button" class="w-full border border-gray-300 dark:border-gray-600 font-medium py-2.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition">Criar nova conta</button>
+          <button
+            id="btnCriarConta"
+            type="button"
+            class="w-full border border-gray-300 dark:border-gray-600 font-medium py-2.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition"
+          >
+            Criar nova conta
+          </button>
 
           <div class="relative text-center text-xs text-gray-500 dark:text-gray-300">
             <span class="px-2 bg-white dark:bg-gray-800 relative z-10">ou</span>
-            <div class="absolute left-0 right-0 top-1/2 border-t border-gray-200 dark:border-gray-700 -z-0"></div>
+            <div
+              class="absolute left-0 right-0 top-1/2 border-t border-gray-200 dark:border-gray-700 -z-0"
+            ></div>
           </div>
 
-          <button id="btnLoginGoogle" type="button" class="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-gradient-to-r from-red-500 to-yellow-500 text-white font-semibold shadow-md hover:opacity-90 transition">
+          <button
+            id="btnLoginGoogle"
+            type="button"
+            class="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-gradient-to-r from-red-500 to-yellow-500 text-white font-semibold shadow-md hover:opacity-90 transition"
+          >
             <i class="fa-brands fa-google text-lg"></i>
             Entrar com Google
           </button>
@@ -191,11 +270,13 @@
     </div>
 
     <!-- Botão de tema -->
-    <button id="btn-tema" class="fixed top-6 right-4 p-2 rounded-full shadow bg-white dark:bg-gray-800 text-gray-800 dark:text-white transition-colors">
+    <button
+      id="btn-tema"
+      class="fixed top-6 right-4 p-2 rounded-full shadow bg-white dark:bg-gray-800 text-gray-800 dark:text-white transition-colors"
+    >
       <i data-lucide="moon" id="icone-tema"></i>
     </button>
 
-  <script type="module" src="./assets/js/main.js"></script>
-
+    <script type="module" src="./assets/js/main.js"></script>
   </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -124,25 +124,70 @@
       Instalar App
     </button>
 
-    <!-- Botão de login Social -->
-    <div class="fixed top-4 right-16 z-50 flex items-center gap-3 bg-gray-100 dark:bg-gray-800 px-4 py-2 rounded-2xl shadow-lg border border-gray-200 dark:border-gray-700">
-      <!-- Botão Login Google -->
-      <button id="btnLoginGoogle" 
-        class="flex items-center gap-2 px-4 py-2 rounded-xl bg-gradient-to-r from-red-500 to-yellow-500 text-white font-medium shadow-md hover:opacity-90 transition">
-        <i class="fa-brands fa-google text-lg"></i>
-        Entrar
+    <!-- Ações de autenticação -->
+    <div class="fixed top-4 right-16 z-50">
+      <button id="btnAbrirLoginModal"
+              class="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-green-600 hover:bg-green-700 text-white font-semibold shadow-md transition">
+        <i data-lucide="log-in" class="w-4 h-4"></i>
+        Login
       </button>
 
-      <!-- Status -->
-      <p id="status" 
-        class="px-4 py-2 text-sm rounded-xl bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-200 shadow-inner min-w-[100px] text-center">
-      </p>
+      <div id="userMenuContainer" class="hidden relative">
+        <button id="btnAvatar" type="button" aria-expanded="false"
+                class="w-11 h-11 rounded-full overflow-hidden border-2 border-green-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-100 shadow-md flex items-center justify-center">
+          <img id="avatarImage" alt="Avatar do usuário" class="w-full h-full object-cover hidden" />
+          <span id="avatarFallback" class="inline-flex items-center justify-center"></span>
+        </button>
 
-      <!-- Botão Logout -->
-      <button id="btnLogout" 
-        class="flex items-center justify-center px-3 py-2 rounded-xl bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600 transition shadow-md">
-        <i data-lucide="log-out" class="w-5 h-5"></i>
-      </button>
+        <div id="userDropdown" class="hidden absolute right-0 mt-2 w-60 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-xl p-2">
+          <div class="px-3 py-2 border-b border-gray-200 dark:border-gray-700 mb-2">
+            <p id="nomeUsuario" class="text-sm font-semibold">Não autenticado</p>
+            <p id="emailUsuario" class="text-xs text-gray-500 dark:text-gray-300">Faça login para continuar</p>
+          </div>
+          <button id="btnEditarPerfil" class="w-full text-left px-3 py-2 text-sm rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition">Editar perfil</button>
+          <button id="btnLogout" class="w-full text-left px-3 py-2 text-sm rounded-lg text-red-600 hover:bg-red-50 dark:hover:bg-red-950/40 transition">Sair</button>
+        </div>
+      </div>
+    </div>
+
+    <div id="loginModal" class="hidden fixed inset-0 z-[70]">
+      <div id="loginModalOverlay" class="absolute inset-0 bg-black/50"></div>
+      <div class="absolute inset-0 flex items-center justify-center p-4">
+        <div class="w-full max-w-sm bg-white dark:bg-gray-800 rounded-2xl shadow-2xl border border-gray-200 dark:border-gray-700 p-6 space-y-4 relative">
+          <button id="btnFecharLoginModal" type="button" class="absolute top-3 right-3 p-1 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700">
+            <i data-lucide="x" class="w-5 h-5"></i>
+          </button>
+
+          <div>
+            <h3 class="text-xl font-bold">Entrar na calculadora</h3>
+            <p class="text-sm text-gray-500 dark:text-gray-300">Use seu email/senha ou continue com Google.</p>
+          </div>
+
+          <form id="loginForm" class="space-y-3">
+            <div>
+              <label for="emailLogin" class="block text-sm mb-1">Email</label>
+              <input id="emailLogin" type="email" required class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2" placeholder="voce@email.com" />
+            </div>
+            <div>
+              <label for="senhaLogin" class="block text-sm mb-1">Senha</label>
+              <input id="senhaLogin" type="password" required class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2" placeholder="••••••••" />
+            </div>
+            <button type="submit" class="w-full bg-green-600 hover:bg-green-700 text-white font-semibold py-2.5 rounded-lg transition">Logar</button>
+          </form>
+
+          <button id="btnCriarConta" type="button" class="w-full border border-gray-300 dark:border-gray-600 font-medium py-2.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition">Criar nova conta</button>
+
+          <div class="relative text-center text-xs text-gray-500 dark:text-gray-300">
+            <span class="px-2 bg-white dark:bg-gray-800 relative z-10">ou</span>
+            <div class="absolute left-0 right-0 top-1/2 border-t border-gray-200 dark:border-gray-700 -z-0"></div>
+          </div>
+
+          <button id="btnLoginGoogle" type="button" class="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-gradient-to-r from-red-500 to-yellow-500 text-white font-semibold shadow-md hover:opacity-90 transition">
+            <i class="fa-brands fa-google text-lg"></i>
+            Entrar com Google
+          </button>
+        </div>
+      </div>
     </div>
 
     <!-- Botão de tema -->

--- a/app.html
+++ b/app.html
@@ -125,7 +125,7 @@
     </button>
 
     <!-- Ações de autenticação -->
-    <div class="fixed top-4 right-16 z-50">
+    <div class="fixed top-6 right-16 z-50">
       <button id="btnAbrirLoginModal"
               class="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-green-600 hover:bg-green-700 text-white font-semibold shadow-md transition">
         <i data-lucide="log-in" class="w-4 h-4"></i>
@@ -134,7 +134,7 @@
 
       <div id="userMenuContainer" class="hidden relative">
         <button id="btnAvatar" type="button" aria-expanded="false"
-                class="w-11 h-11 rounded-full overflow-hidden border-2 border-green-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-100 shadow-md flex items-center justify-center">
+                class="w-10 h-10 rounded-full overflow-hidden bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-100 shadow-md flex items-center justify-center">
           <img id="avatarImage" alt="Avatar do usuário" class="w-full h-full object-cover hidden" />
           <span id="avatarFallback" class="inline-flex items-center justify-center"></span>
         </button>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -15,6 +15,8 @@
     --color-green-600: oklch(62.7% 0.194 149.214);
     --color-green-700: oklch(52.7% 0.154 150.069);
     --color-blue-600: oklch(54.6% 0.245 262.881);
+    --color-blue-700: oklch(48.8% 0.243 264.376);
+    --color-blue-800: oklch(42.4% 0.199 265.638);
     --color-gray-50: oklch(98.5% 0.002 247.839);
     --color-gray-100: oklch(96.7% 0.003 264.542);
     --color-gray-300: oklch(87.2% 0.01 258.338);
@@ -222,11 +224,23 @@
   .bottom-2 {
     bottom: calc(var(--spacing) * 2);
   }
+  .bottom-4 {
+    bottom: calc(var(--spacing) * 4);
+  }
+  .bottom-8 {
+    bottom: calc(var(--spacing) * 8);
+  }
   .left-0 {
     left: calc(var(--spacing) * 0);
   }
+  .left-1 {
+    left: calc(var(--spacing) * 1);
+  }
   .left-1\/2 {
     left: calc(1/2 * 100%);
+  }
+  .left-4 {
+    left: calc(var(--spacing) * 4);
   }
   .z-50 {
     z-index: 50;
@@ -267,6 +281,9 @@
   .mb-8 {
     margin-bottom: calc(var(--spacing) * 8);
   }
+  .ml-4 {
+    margin-left: calc(var(--spacing) * 4);
+  }
   .block {
     display: block;
   }
@@ -275,6 +292,9 @@
   }
   .hidden {
     display: none;
+  }
+  .table {
+    display: table;
   }
   .h-4 {
     height: calc(var(--spacing) * 4);
@@ -330,6 +350,13 @@
   .flex-1 {
     flex: 1;
   }
+  .border-collapse {
+    border-collapse: collapse;
+  }
+  .-translate-x-1 {
+    --tw-translate-x: calc(var(--spacing) * -1);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
   .-translate-x-1\/2 {
     --tw-translate-x: calc(calc(1/2 * 100%) * -1);
     translate: var(--tw-translate-x) var(--tw-translate-y);
@@ -339,6 +366,9 @@
   }
   .cursor-pointer {
     cursor: pointer;
+  }
+  .resize {
+    resize: both;
   }
   .flex-col {
     flex-direction: column;
@@ -388,6 +418,9 @@
   .overflow-y-auto {
     overflow-y: auto;
   }
+  .rounded {
+    border-radius: 0.25rem;
+  }
   .rounded-2xl {
     border-radius: var(--radius-2xl);
   }
@@ -430,6 +463,9 @@
   .border-yellow-500 {
     border-color: var(--color-yellow-500);
   }
+  .bg-blue-600 {
+    background-color: var(--color-blue-600);
+  }
   .bg-gray-50 {
     background-color: var(--color-gray-50);
   }
@@ -450,6 +486,9 @@
   }
   .px-2 {
     padding-inline: calc(var(--spacing) * 2);
+  }
+  .px-3 {
+    padding-inline: calc(var(--spacing) * 3);
   }
   .px-4 {
     padding-inline: calc(var(--spacing) * 4);
@@ -530,6 +569,9 @@
   .text-white {
     color: var(--color-white);
   }
+  .underline {
+    text-decoration-line: underline;
+  }
   .opacity-0 {
     opacity: 0%;
   }
@@ -548,6 +590,10 @@
   .shadow-sm {
     --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .outline {
+    outline-style: var(--tw-outline-style);
+    outline-width: 1px;
   }
   .transition {
     transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter, display, visibility, content-visibility, overlay, pointer-events;
@@ -651,6 +697,16 @@
       border-color: var(--color-gray-700);
     }
   }
+  .dark\:bg-blue-800 {
+    &:where(.dark, .dark *) {
+      background-color: var(--color-blue-800);
+    }
+  }
+  .dark\:bg-gray-100 {
+    &:where(.dark, .dark *) {
+      background-color: var(--color-gray-100);
+    }
+  }
   .dark\:bg-gray-700 {
     &:where(.dark, .dark *) {
       background-color: var(--color-gray-700);
@@ -664,6 +720,16 @@
   .dark\:bg-gray-900 {
     &:where(.dark, .dark *) {
       background-color: var(--color-gray-900);
+    }
+  }
+  .dark\:bg-green-600 {
+    &:where(.dark, .dark *) {
+      background-color: var(--color-green-600);
+    }
+  }
+  .dark\:text-blue-700 {
+    &:where(.dark, .dark *) {
+      color: var(--color-blue-700);
     }
   }
   .dark\:text-gray-100 {
@@ -810,6 +876,11 @@
   inherits: false;
   initial-value: 0 0 #0000;
 }
+@property --tw-outline-style {
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
+}
 @property --tw-duration {
   syntax: "*";
   inherits: false;
@@ -846,6 +917,7 @@
       --tw-ring-offset-width: 0px;
       --tw-ring-offset-color: #fff;
       --tw-ring-offset-shadow: 0 0 #0000;
+      --tw-outline-style: solid;
       --tw-duration: initial;
       --tw-ease: initial;
     }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -7,9 +7,12 @@
       "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
       "Courier New", monospace;
+    --color-red-50: oklch(97.1% 0.013 17.38);
     --color-red-100: oklch(93.6% 0.032 17.717);
     --color-red-500: oklch(63.7% 0.237 25.331);
+    --color-red-600: oklch(57.7% 0.245 27.325);
     --color-red-900: oklch(39.6% 0.141 25.723);
+    --color-red-950: oklch(25.8% 0.092 26.042);
     --color-yellow-500: oklch(79.5% 0.184 86.047);
     --color-green-100: oklch(96.2% 0.044 156.743);
     --color-green-500: oklch(72.3% 0.219 149.579);
@@ -27,13 +30,15 @@
     --color-gray-700: oklch(37.3% 0.034 259.733);
     --color-gray-800: oklch(27.8% 0.033 256.848);
     --color-gray-900: oklch(21% 0.034 264.665);
+    --color-black: #000;
     --color-white: #fff;
     --spacing: 0.25rem;
     --container-sm: 24rem;
     --container-md: 28rem;
-    --container-2xl: 42rem;
     --container-4xl: 56rem;
     --container-6xl: 72rem;
+    --text-xs: 0.75rem;
+    --text-xs--line-height: calc(1 / 0.75);
     --text-sm: 0.875rem;
     --text-sm--line-height: calc(1.25 / 0.875);
     --text-lg: 1.125rem;
@@ -220,11 +225,26 @@
   .static {
     position: static;
   }
+  .inset-0 {
+    inset: calc(var(--spacing) * 0);
+  }
+  .top-1\/2 {
+    top: calc(1/2 * 100%);
+  }
+  .top-3 {
+    top: calc(var(--spacing) * 3);
+  }
   .top-4 {
     top: calc(var(--spacing) * 4);
   }
   .top-6 {
     top: calc(var(--spacing) * 6);
+  }
+  .right-0 {
+    right: calc(var(--spacing) * 0);
+  }
+  .right-3 {
+    right: calc(var(--spacing) * 3);
   }
   .right-4 {
     right: calc(var(--spacing) * 4);
@@ -247,8 +267,17 @@
   .left-4 {
     left: calc(var(--spacing) * 4);
   }
+  .-z-0 {
+    z-index: calc(0 * -1);
+  }
+  .z-10 {
+    z-index: 10;
+  }
   .z-50 {
     z-index: 50;
+  }
+  .z-\[70\] {
+    z-index: 70;
   }
   .col-span-2 {
     grid-column: span 2 / span 2;
@@ -319,9 +348,6 @@
   .hidden {
     display: none;
   }
-  .inline-block {
-    display: inline-block;
-  }
   .inline-flex {
     display: inline-flex;
   }
@@ -339,6 +365,9 @@
   }
   .h-11 {
     height: calc(var(--spacing) * 11);
+  }
+  .h-full {
+    height: 100%;
   }
   .max-h-40 {
     max-height: calc(var(--spacing) * 40);
@@ -367,6 +396,9 @@
   .w-16 {
     width: calc(var(--spacing) * 16);
   }
+  .w-60 {
+    width: calc(var(--spacing) * 60);
+  }
   .w-80 {
     width: calc(var(--spacing) * 80);
   }
@@ -384,9 +416,6 @@
   }
   .max-w-sm {
     max-width: var(--container-sm);
-  }
-  .min-w-\[100px\] {
-    min-width: 100px;
   }
   .flex-1 {
     flex: 1;
@@ -493,9 +522,17 @@
     border-style: var(--tw-border-style);
     border-width: 1px;
   }
+  .border-2 {
+    border-style: var(--tw-border-style);
+    border-width: 2px;
+  }
   .border-t {
     border-top-style: var(--tw-border-style);
     border-top-width: 1px;
+  }
+  .border-b {
+    border-bottom-style: var(--tw-border-style);
+    border-bottom-width: 1px;
   }
   .border-l-4 {
     border-left-style: var(--tw-border-style);
@@ -513,23 +550,26 @@
   .border-green-500 {
     border-color: var(--color-green-500);
   }
+  .border-green-600 {
+    border-color: var(--color-green-600);
+  }
   .border-red-500 {
     border-color: var(--color-red-500);
   }
   .border-yellow-500 {
     border-color: var(--color-yellow-500);
   }
+  .bg-black\/50 {
+    background-color: color-mix(in srgb, #000 50%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-black) 50%, transparent);
+    }
+  }
   .bg-blue-600 {
     background-color: var(--color-blue-600);
   }
   .bg-gray-50 {
     background-color: var(--color-gray-50);
-  }
-  .bg-gray-100 {
-    background-color: var(--color-gray-100);
-  }
-  .bg-gray-200 {
-    background-color: var(--color-gray-200);
   }
   .bg-gray-700 {
     background-color: var(--color-gray-700);
@@ -566,6 +606,12 @@
   .to-yellow-500 {
     --tw-gradient-to: var(--color-yellow-500);
     --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .object-cover {
+    object-fit: cover;
+  }
+  .p-1 {
+    padding: calc(var(--spacing) * 1);
   }
   .p-2 {
     padding: calc(var(--spacing) * 2);
@@ -608,6 +654,9 @@
   }
   .py-4 {
     padding-block: calc(var(--spacing) * 4);
+  }
+  .py-6 {
+    padding-block: calc(var(--spacing) * 6);
   }
   .py-8 {
     padding-block: calc(var(--spacing) * 8);
@@ -652,6 +701,14 @@
   .text-xl {
     font-size: var(--text-xl);
     line-height: var(--tw-leading, var(--text-xl--line-height));
+  }
+  .text-xs {
+    font-size: var(--text-xs);
+    line-height: var(--tw-leading, var(--text-xs--line-height));
+  }
+  .leading-none {
+    --tw-leading: 1;
+    line-height: 1;
   }
   .leading-tight {
     --tw-leading: var(--leading-tight);
@@ -699,6 +756,9 @@
   .text-red-500 {
     color: var(--color-red-500);
   }
+  .text-red-600 {
+    color: var(--color-red-600);
+  }
   .text-white {
     color: var(--color-white);
   }
@@ -715,8 +775,8 @@
     --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
-  .shadow-inner {
-    --tw-shadow: inset 0 2px 4px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.05));
+  .shadow-2xl {
+    --tw-shadow: 0 25px 50px -12px var(--tw-shadow-color, rgb(0 0 0 / 0.25));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
   .shadow-lg {
@@ -781,17 +841,17 @@
       }
     }
   }
-  .hover\:bg-gray-300 {
-    &:hover {
-      @media (hover: hover) {
-        background-color: var(--color-gray-300);
-      }
-    }
-  }
   .hover\:bg-green-700 {
     &:hover {
       @media (hover: hover) {
         background-color: var(--color-green-700);
+      }
+    }
+  }
+  .hover\:bg-red-50 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-red-50);
       }
     }
   }
@@ -931,11 +991,6 @@
       color: var(--color-gray-100);
     }
   }
-  .dark\:text-gray-200 {
-    &:where(.dark, .dark *) {
-      color: var(--color-gray-200);
-    }
-  }
   .dark\:text-gray-300 {
     &:where(.dark, .dark *) {
       color: var(--color-gray-300);
@@ -956,11 +1011,11 @@
       color: var(--color-white);
     }
   }
-  .dark\:hover\:bg-gray-600 {
+  .dark\:hover\:bg-gray-700 {
     &:where(.dark, .dark *) {
       &:hover {
         @media (hover: hover) {
-          background-color: var(--color-gray-600);
+          background-color: var(--color-gray-700);
         }
       }
     }
@@ -970,6 +1025,18 @@
       &:hover {
         @media (hover: hover) {
           background-color: var(--color-red-900);
+        }
+      }
+    }
+  }
+  .dark\:hover\:bg-red-950\/40 {
+    &:where(.dark, .dark *) {
+      &:hover {
+        @media (hover: hover) {
+          background-color: color-mix(in srgb, oklch(25.8% 0.092 26.042) 40%, transparent);
+          @supports (color: color-mix(in lab, red, red)) {
+            background-color: color-mix(in oklab, var(--color-red-950) 40%, transparent);
+          }
         }
       }
     }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -326,11 +326,17 @@
   .mt-2 {
     margin-top: calc(var(--spacing) * 2);
   }
+  .mt-6 {
+    margin-top: calc(var(--spacing) * 6);
+  }
   .mt-10 {
     margin-top: calc(var(--spacing) * 10);
   }
   .mt-15 {
     margin-top: calc(var(--spacing) * 15);
+  }
+  .mt-16 {
+    margin-top: calc(var(--spacing) * 16);
   }
   .mb-1 {
     margin-bottom: calc(var(--spacing) * 1);
@@ -389,6 +395,9 @@
   .h-11 {
     height: calc(var(--spacing) * 11);
   }
+  .h-\[100dvh\] {
+    height: 100dvh;
+  }
   .h-full {
     height: 100%;
   }
@@ -397,6 +406,9 @@
   }
   .max-h-130 {
     max-height: calc(var(--spacing) * 130);
+  }
+  .min-h-0 {
+    min-height: calc(var(--spacing) * 0);
   }
   .min-h-screen {
     min-height: 100vh;
@@ -736,6 +748,9 @@
   }
   .pb-50 {
     padding-bottom: calc(var(--spacing) * 50);
+  }
+  .pb-\[calc\(120px\+env\(safe-area-inset-bottom\)\)\] {
+    padding-bottom: calc(120px + env(safe-area-inset-bottom));
   }
   .text-center {
     text-align: center;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -41,6 +41,8 @@
     --text-xs--line-height: calc(1 / 0.75);
     --text-sm: 0.875rem;
     --text-sm--line-height: calc(1.25 / 0.875);
+    --text-base: 1rem;
+    --text-base--line-height: calc(1.5 / 1);
     --text-lg: 1.125rem;
     --text-lg--line-height: calc(1.75 / 1.125);
     --text-xl: 1.25rem;
@@ -261,6 +263,9 @@
   .bottom-2 {
     bottom: calc(var(--spacing) * 2);
   }
+  .bottom-6 {
+    bottom: calc(var(--spacing) * 6);
+  }
   .left-0 {
     left: calc(var(--spacing) * 0);
   }
@@ -479,6 +484,9 @@
   .items-start {
     align-items: flex-start;
   }
+  .items-stretch {
+    align-items: stretch;
+  }
   .justify-between {
     justify-content: space-between;
   }
@@ -496,6 +504,9 @@
   }
   .gap-4 {
     gap: calc(var(--spacing) * 4);
+  }
+  .gap-8 {
+    gap: calc(var(--spacing) * 8);
   }
   .gap-10 {
     gap: calc(var(--spacing) * 10);
@@ -519,6 +530,13 @@
       --tw-space-y-reverse: 0;
       margin-block-start: calc(calc(var(--spacing) * 5) * var(--tw-space-y-reverse));
       margin-block-end: calc(calc(var(--spacing) * 5) * calc(1 - var(--tw-space-y-reverse)));
+    }
+  }
+  .space-y-12 {
+    :where(& > :not(:last-child)) {
+      --tw-space-y-reverse: 0;
+      margin-block-start: calc(calc(var(--spacing) * 12) * var(--tw-space-y-reverse));
+      margin-block-end: calc(calc(var(--spacing) * 12) * calc(1 - var(--tw-space-y-reverse)));
     }
   }
   .space-y-16 {
@@ -732,6 +750,10 @@
   .text-3xl {
     font-size: var(--text-3xl);
     line-height: var(--tw-leading, var(--text-3xl--line-height));
+  }
+  .text-base {
+    font-size: var(--text-base);
+    line-height: var(--tw-leading, var(--text-base--line-height));
   }
   .text-lg {
     font-size: var(--text-lg);
@@ -948,9 +970,44 @@
       outline-style: none;
     }
   }
+  .sm\:top-6 {
+    @media (width >= 40rem) {
+      top: calc(var(--spacing) * 6);
+    }
+  }
+  .sm\:bottom-auto {
+    @media (width >= 40rem) {
+      bottom: auto;
+    }
+  }
   .sm\:inline {
     @media (width >= 40rem) {
       display: inline;
+    }
+  }
+  .sm\:h-6 {
+    @media (width >= 40rem) {
+      height: calc(var(--spacing) * 6);
+    }
+  }
+  .sm\:h-11 {
+    @media (width >= 40rem) {
+      height: calc(var(--spacing) * 11);
+    }
+  }
+  .sm\:w-6 {
+    @media (width >= 40rem) {
+      width: calc(var(--spacing) * 6);
+    }
+  }
+  .sm\:w-11 {
+    @media (width >= 40rem) {
+      width: calc(var(--spacing) * 11);
+    }
+  }
+  .sm\:w-auto {
+    @media (width >= 40rem) {
+      width: auto;
     }
   }
   .sm\:flex-row {
@@ -963,6 +1020,59 @@
       align-items: center;
     }
   }
+  .sm\:justify-between {
+    @media (width >= 40rem) {
+      justify-content: space-between;
+    }
+  }
+  .sm\:space-y-16 {
+    @media (width >= 40rem) {
+      :where(& > :not(:last-child)) {
+        --tw-space-y-reverse: 0;
+        margin-block-start: calc(calc(var(--spacing) * 16) * var(--tw-space-y-reverse));
+        margin-block-end: calc(calc(var(--spacing) * 16) * calc(1 - var(--tw-space-y-reverse)));
+      }
+    }
+  }
+  .sm\:p-8 {
+    @media (width >= 40rem) {
+      padding: calc(var(--spacing) * 8);
+    }
+  }
+  .sm\:px-6 {
+    @media (width >= 40rem) {
+      padding-inline: calc(var(--spacing) * 6);
+    }
+  }
+  .sm\:py-8 {
+    @media (width >= 40rem) {
+      padding-block: calc(var(--spacing) * 8);
+    }
+  }
+  .sm\:text-2xl {
+    @media (width >= 40rem) {
+      font-size: var(--text-2xl);
+      line-height: var(--tw-leading, var(--text-2xl--line-height));
+    }
+  }
+  .sm\:text-3xl {
+    @media (width >= 40rem) {
+      font-size: var(--text-3xl);
+      line-height: var(--tw-leading, var(--text-3xl--line-height));
+    }
+  }
+  .sm\:text-lg {
+    @media (width >= 40rem) {
+      font-size: var(--text-lg);
+      line-height: var(--tw-leading, var(--text-lg--line-height));
+    }
+  }
+  .sm\:text-xl {
+    @media (width >= 40rem) {
+      font-size: var(--text-xl);
+      line-height: var(--tw-leading, var(--text-xl--line-height));
+    }
+  }
   .md\:grid-cols-2 {
     @media (width >= 48rem) {
       grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -971,6 +1081,11 @@
   .md\:grid-cols-3 {
     @media (width >= 48rem) {
       grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+  .md\:gap-10 {
+    @media (width >= 48rem) {
+      gap: calc(var(--spacing) * 10);
     }
   }
   .md\:p-10 {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -228,6 +228,9 @@
   .inset-0 {
     inset: calc(var(--spacing) * 0);
   }
+  .top-1 {
+    top: calc(var(--spacing) * 1);
+  }
   .top-1\/2 {
     top: calc(1/2 * 100%);
   }
@@ -260,6 +263,9 @@
   }
   .left-0 {
     left: calc(var(--spacing) * 0);
+  }
+  .left-1 {
+    left: calc(var(--spacing) * 1);
   }
   .left-1\/2 {
     left: calc(1/2 * 100%);
@@ -302,6 +308,9 @@
   }
   .mx-auto {
     margin-inline: auto;
+  }
+  .mt-0 {
+    margin-top: calc(var(--spacing) * 0);
   }
   .mt-0\.5 {
     margin-top: calc(var(--spacing) * 0.5);
@@ -351,6 +360,9 @@
   .inline-flex {
     display: inline-flex;
   }
+  .table {
+    display: table;
+  }
   .h-4 {
     height: calc(var(--spacing) * 4);
   }
@@ -362,6 +374,12 @@
   }
   .h-8 {
     height: calc(var(--spacing) * 8);
+  }
+  .h-9 {
+    height: calc(var(--spacing) * 9);
+  }
+  .h-10 {
+    height: calc(var(--spacing) * 10);
   }
   .h-11 {
     height: calc(var(--spacing) * 11);
@@ -389,6 +407,12 @@
   }
   .w-8 {
     width: calc(var(--spacing) * 8);
+  }
+  .w-9 {
+    width: calc(var(--spacing) * 9);
+  }
+  .w-10 {
+    width: calc(var(--spacing) * 10);
   }
   .w-11 {
     width: calc(var(--spacing) * 11);
@@ -420,6 +444,13 @@
   .flex-1 {
     flex: 1;
   }
+  .border-collapse {
+    border-collapse: collapse;
+  }
+  .-translate-x-1 {
+    --tw-translate-x: calc(var(--spacing) * -1);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
   .-translate-x-1\/2 {
     --tw-translate-x: calc(calc(1/2 * 100%) * -1);
     translate: var(--tw-translate-x) var(--tw-translate-y);
@@ -429,6 +460,9 @@
   }
   .cursor-pointer {
     cursor: pointer;
+  }
+  .resize {
+    resize: both;
   }
   .grid-cols-3 {
     grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -547,6 +581,12 @@
   .border-gray-400 {
     border-color: var(--color-gray-400);
   }
+  .border-gray-600 {
+    border-color: var(--color-gray-600);
+  }
+  .border-gray-700 {
+    border-color: var(--color-gray-700);
+  }
   .border-green-500 {
     border-color: var(--color-green-500);
   }
@@ -558,6 +598,9 @@
   }
   .border-yellow-500 {
     border-color: var(--color-yellow-500);
+  }
+  .bg-black {
+    background-color: var(--color-black);
   }
   .bg-black\/50 {
     background-color: color-mix(in srgb, #000 50%, transparent);
@@ -768,6 +811,9 @@
       color: color-mix(in oklab, var(--color-white) 95%, transparent);
     }
   }
+  .underline {
+    text-decoration-line: underline;
+  }
   .opacity-0 {
     opacity: 0%;
   }
@@ -794,6 +840,10 @@
   .shadow-xl {
     --tw-shadow: 0 20px 25px -5px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 8px 10px -6px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .outline {
+    outline-style: var(--tw-outline-style);
+    outline-width: 1px;
   }
   .transition {
     transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter, display, visibility, content-visibility, overlay, pointer-events;
@@ -1202,6 +1252,11 @@
   inherits: false;
   initial-value: 0 0 #0000;
 }
+@property --tw-outline-style {
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
+}
 @property --tw-duration {
   syntax: "*";
   inherits: false;
@@ -1248,6 +1303,7 @@
       --tw-ring-offset-width: 0px;
       --tw-ring-offset-color: #fff;
       --tw-ring-offset-shadow: 0 0 #0000;
+      --tw-outline-style: solid;
       --tw-duration: initial;
       --tw-ease: initial;
     }

--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -1,8 +1,31 @@
 import { supabase } from './supabase.js';
 
-function limparFragmentoOAuth() {
-  const cleanUrl = `${window.location.origin}${window.location.pathname}${window.location.search}`;
-  window.history.replaceState({}, document.title, cleanUrl);
+/**
+ * Retorna a URL absoluta do app.html no mesmo diretório do projeto,
+ * evitando carregar query/hash da página atual.
+ */
+function getAppRedirectUrl() {
+  const path = window.location.pathname;
+  const baseDir = path.endsWith('/')
+    ? path
+    : path.substring(0, path.lastIndexOf('/') + 1);
+
+  return `${window.location.origin}${baseDir}app.html`;
+}
+
+function limparParametrosOAuthDaUrl() {
+  const url = new URL(window.location.href);
+
+  // Remove parâmetros comuns do OAuth / errors
+  url.searchParams.delete('code');
+  url.searchParams.delete('error');
+  url.searchParams.delete('error_code');
+  url.searchParams.delete('error_description');
+
+  // Remove o hash (caso implicit flow)
+  url.hash = '';
+
+  window.history.replaceState({}, document.title, url.toString());
 }
 
 function extrairTokensDoHash() {
@@ -24,42 +47,54 @@ function extrairTokensDoHash() {
   };
 }
 
+/**
+ * Hidrata sessão retornando do OAuth.
+ * - Suporta PKCE/code flow: ?code=...
+ * - Fallback para implicit flow: #access_token=...
+ */
 export async function hidratarSessaoDaUrl() {
-  const tokens = extrairTokensDoHash();
-  if (!tokens) return null;
+  try {
+    const url = new URL(window.location.href);
+    const code = url.searchParams.get('code');
 
-  const { data, error } = await supabase.auth.setSession(tokens);
-  if (error) {
-    console.error('Erro ao hidratar sessão da URL:', error.message);
-    limparFragmentoOAuth();
+    // 1) PKCE / Authorization Code Flow
+    if (code) {
+      const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+      if (error) {
+        console.error('Erro ao trocar code por sessão:', error.message);
+        limparParametrosOAuthDaUrl();
+        return null;
+      }
+
+      limparParametrosOAuthDaUrl();
+      return data.session?.user || null;
+    }
+
+    // 2) Implicit Flow (tokens no hash)
+    const tokens = extrairTokensDoHash();
+    if (!tokens) return null;
+
+    const { data, error } = await supabase.auth.setSession(tokens);
+    if (error) {
+      console.error('Erro ao hidratar sessão do hash:', error.message);
+      limparParametrosOAuthDaUrl();
+      return null;
+    }
+
+    limparParametrosOAuthDaUrl();
+    return data.session?.user || null;
+  } catch (err) {
+    console.error('Erro inesperado ao hidratar sessão:', err);
+    limparParametrosOAuthDaUrl();
     return null;
   }
-
-  limparFragmentoOAuth();
-  return data.session?.user || null;
 }
 
-async function sincronizarPerfil(user) {
-  if (!user) return null;
-
-  const payload = {
-    id: user.id,
-    email: user.email || null,
-    full_name: user.user_metadata?.full_name || user.user_metadata?.name || null,
-    avatar_url: user.user_metadata?.avatar_url || null,
-    provider: user.app_metadata?.provider || null
-  };
-
-  const { error } = await supabase
-    .from('profiles')
-    .upsert(payload, { onConflict: 'id' });
-
-  if (error) {
-    console.error('Erro ao sincronizar perfil:', error.message);
-  }
-
-  return user;
-}
+// --------------------------------------------
+// IMPORTANTE
+// Profiles serão criados pelo TRIGGER no banco.
+// Não faça upsert no client (evita 401).
+// --------------------------------------------
 
 // Registrar usuário por email
 export async function registrarEmail(email, senha) {
@@ -67,16 +102,14 @@ export async function registrarEmail(email, senha) {
     email,
     password: senha
   });
+
   if (error) {
     console.error('Erro no registro:', error.message);
     return null;
   }
 
-  if (data.user) {
-    await sincronizarPerfil(data.user);
-  }
-
-  return data.user;
+  // NÃO sincroniza profiles aqui (DB trigger faz isso)
+  return data.user || null;
 }
 
 // Login com email/senha
@@ -85,41 +118,43 @@ export async function loginEmail(email, senha) {
     email,
     password: senha
   });
+
   if (error) {
     console.error('Erro no login:', error.message);
     return null;
   }
 
-  if (data.user) {
-    await sincronizarPerfil(data.user);
-  }
-
-  return data.user;
+  // NÃO sincroniza profiles aqui (evita 401)
+  return data.user || null;
 }
 
 // Login social (Google)
 export async function loginGoogle() {
-  const redirectTo = new URL('app.html', window.location.href).toString();
+  const redirectTo = getAppRedirectUrl();
+
   const { error } = await supabase.auth.signInWithOAuth({
     provider: 'google',
-    options: {
-      redirectTo
-    }
+    options: { redirectTo }
   });
-  if (error) console.error('Erro no login Google:', error.message);
+
+  if (error) {
+    console.error('Erro no login Google:', error.message);
+    return null;
+  }
+
+  return true;
 }
 
 export async function atualizarPerfil(data) {
   const { data: updatedData, error } = await supabase.auth.updateUser(data);
+
   if (error) {
     console.error('Erro ao atualizar perfil:', error.message);
     return null;
   }
 
-  if (updatedData.user) {
-    await sincronizarPerfil(updatedData.user);
-  }
-
+  // Se você quiser refletir mudanças no profiles,
+  // faça isso no banco (trigger on update) ou via RPC/Edge Function.
   return updatedData.user || null;
 }
 
@@ -131,34 +166,30 @@ export async function getUsuarioAtual() {
 
 // Checar sessão ao carregar a aplicação
 export async function checarSessao() {
+  // 1) Se veio de OAuth callback, hidrata sessão
   const userDaUrl = await hidratarSessaoDaUrl();
-  if (userDaUrl) {
-    await sincronizarPerfil(userDaUrl);
-    return userDaUrl;
-  }
+  if (userDaUrl) return userDaUrl;
 
+  // 2) Se já existe sessão salva no browser
   const { data, error } = await supabase.auth.getSession();
   if (error) {
     console.error('Erro ao recuperar sessão:', error.message);
     return null;
   }
 
-  if (data.session?.user) {
-    await sincronizarPerfil(data.session.user);
-  }
-
   return data.session?.user || null;
 }
 
+/**
+ * Escuta mudanças de sessão.
+ * Retorna uma função para "desinscrever".
+ */
 export function escutarMudancaSessao(callback) {
-  supabase.auth.onAuthStateChange((_event, session) => {
-    if (session?.user) {
-      sincronizarPerfil(session.user);
-      callback(session.user);
-    } else {
-      callback(null);
-    }
+  const { data } = supabase.auth.onAuthStateChange((_event, session) => {
+    callback(session?.user || null);
   });
+
+  return () => data.subscription.unsubscribe();
 }
 
 // Logout

--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -22,13 +22,23 @@ export async function loginEmail(email, senha) {
 
 // Login social (Google)
 export async function loginGoogle() {
+  const redirectTo = new URL('app.html', window.location.href).toString();
   const { error } = await supabase.auth.signInWithOAuth({
     provider: 'google',
     options: {
-      redirectTo: "http://localhost/calculadora-preco-mercado/" // tem que estar cadastrado no dashboard
+      redirectTo
     }
   });
   if (error) console.error("Erro no login Google:", error.message);
+}
+
+export async function atualizarPerfil(data) {
+  const { data: updatedData, error } = await supabase.auth.updateUser(data);
+  if (error) {
+    console.error('Erro ao atualizar perfil:', error.message);
+    return null;
+  }
+  return updatedData.user || null;
 }
 
 // Pegar usuário logado

--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -1,12 +1,42 @@
 import { supabase } from './supabase.js';
 
+async function sincronizarPerfil(user) {
+  if (!user) return null;
+
+  const payload = {
+    id: user.id,
+    email: user.email || null,
+    full_name: user.user_metadata?.full_name || user.user_metadata?.name || null,
+    avatar_url: user.user_metadata?.avatar_url || null,
+    provider: user.app_metadata?.provider || null
+  };
+
+  const { error } = await supabase
+    .from('profiles')
+    .upsert(payload, { onConflict: 'id' });
+
+  if (error) {
+    console.error('Erro ao sincronizar perfil:', error.message);
+  }
+
+  return user;
+}
+
 // Registrar usuário por email
 export async function registrarEmail(email, senha) {
   const { data, error } = await supabase.auth.signUp({
     email,
     password: senha
   });
-  if (error) console.error("Erro no registro:", error.message);
+  if (error) {
+    console.error('Erro no registro:', error.message);
+    return null;
+  }
+
+  if (data.user) {
+    await sincronizarPerfil(data.user);
+  }
+
   return data.user;
 }
 
@@ -16,7 +46,15 @@ export async function loginEmail(email, senha) {
     email,
     password: senha
   });
-  if (error) console.error("Erro no login:", error.message);
+  if (error) {
+    console.error('Erro no login:', error.message);
+    return null;
+  }
+
+  if (data.user) {
+    await sincronizarPerfil(data.user);
+  }
+
   return data.user;
 }
 
@@ -29,7 +67,7 @@ export async function loginGoogle() {
       redirectTo
     }
   });
-  if (error) console.error("Erro no login Google:", error.message);
+  if (error) console.error('Erro no login Google:', error.message);
 }
 
 export async function atualizarPerfil(data) {
@@ -38,6 +76,11 @@ export async function atualizarPerfil(data) {
     console.error('Erro ao atualizar perfil:', error.message);
     return null;
   }
+
+  if (updatedData.user) {
+    await sincronizarPerfil(updatedData.user);
+  }
+
   return updatedData.user || null;
 }
 
@@ -51,15 +94,21 @@ export async function getUsuarioAtual() {
 export async function checarSessao() {
   const { data, error } = await supabase.auth.getSession();
   if (error) {
-    console.error("Erro ao recuperar sessão:", error.message);
+    console.error('Erro ao recuperar sessão:', error.message);
     return null;
   }
+
+  if (data.session?.user) {
+    await sincronizarPerfil(data.session.user);
+  }
+
   return data.session?.user || null;
 }
 
 export function escutarMudancaSessao(callback) {
   supabase.auth.onAuthStateChange((_event, session) => {
     if (session?.user) {
+      sincronizarPerfil(session.user);
       callback(session.user);
     } else {
       callback(null);
@@ -70,5 +119,5 @@ export function escutarMudancaSessao(callback) {
 // Logout
 export async function logout() {
   await supabase.auth.signOut();
-  alert("Você saiu!");
+  alert('Você saiu!');
 }

--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -1,5 +1,44 @@
 import { supabase } from './supabase.js';
 
+function limparFragmentoOAuth() {
+  const cleanUrl = `${window.location.origin}${window.location.pathname}${window.location.search}`;
+  window.history.replaceState({}, document.title, cleanUrl);
+}
+
+function extrairTokensDoHash() {
+  const hash = window.location.hash?.startsWith('#')
+    ? window.location.hash.slice(1)
+    : window.location.hash;
+
+  if (!hash) return null;
+
+  const params = new URLSearchParams(hash);
+  const accessToken = params.get('access_token');
+  const refreshToken = params.get('refresh_token');
+
+  if (!accessToken || !refreshToken) return null;
+
+  return {
+    access_token: accessToken,
+    refresh_token: refreshToken
+  };
+}
+
+export async function hidratarSessaoDaUrl() {
+  const tokens = extrairTokensDoHash();
+  if (!tokens) return null;
+
+  const { data, error } = await supabase.auth.setSession(tokens);
+  if (error) {
+    console.error('Erro ao hidratar sessão da URL:', error.message);
+    limparFragmentoOAuth();
+    return null;
+  }
+
+  limparFragmentoOAuth();
+  return data.session?.user || null;
+}
+
 async function sincronizarPerfil(user) {
   if (!user) return null;
 
@@ -92,6 +131,12 @@ export async function getUsuarioAtual() {
 
 // Checar sessão ao carregar a aplicação
 export async function checarSessao() {
+  const userDaUrl = await hidratarSessaoDaUrl();
+  if (userDaUrl) {
+    await sincronizarPerfil(userDaUrl);
+    return userDaUrl;
+  }
+
   const { data, error } = await supabase.auth.getSession();
   if (error) {
     console.error('Erro ao recuperar sessão:', error.message);

--- a/assets/js/login.js
+++ b/assets/js/login.js
@@ -1,54 +1,192 @@
-import { loginGoogle, checarSessao, logout, escutarMudancaSessao } from './auth.js';
+import {
+  loginGoogle,
+  checarSessao,
+  logout,
+  escutarMudancaSessao,
+  loginEmail,
+  registrarEmail,
+  atualizarPerfil
+} from './auth.js';
+
+const DEFAULT_AVATAR = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-6 h-6"><path d="M20 21a8 8 0 0 0-16 0"/><circle cx="12" cy="7" r="4"/></svg>`;
 
 export class LoginSocial {
   constructor() {
-    this.status = document.getElementById("status");
-    this.btnLoginGoogle = document.getElementById("btnLoginGoogle");
-    this.btnLogout = document.getElementById("btnLogout");
+    this.btnAbrirModal = document.getElementById('btnAbrirLoginModal');
+    this.modal = document.getElementById('loginModal');
+    this.modalOverlay = document.getElementById('loginModalOverlay');
+    this.btnFecharModal = document.getElementById('btnFecharLoginModal');
+
+    this.formLogin = document.getElementById('loginForm');
+    this.campoEmail = document.getElementById('emailLogin');
+    this.campoSenha = document.getElementById('senhaLogin');
+    this.btnRegistrar = document.getElementById('btnCriarConta');
+    this.btnLoginGoogle = document.getElementById('btnLoginGoogle');
+
+    this.menuContainer = document.getElementById('userMenuContainer');
+    this.btnAvatar = document.getElementById('btnAvatar');
+    this.avatarImage = document.getElementById('avatarImage');
+    this.avatarFallback = document.getElementById('avatarFallback');
+    this.menuDropdown = document.getElementById('userDropdown');
+    this.btnEditarPerfil = document.getElementById('btnEditarPerfil');
+    this.btnLogout = document.getElementById('btnLogout');
+
+    this.nomeUsuario = document.getElementById('nomeUsuario');
+    this.emailUsuario = document.getElementById('emailUsuario');
 
     this.init();
   }
 
   init() {
-    // Botão login Google
-    this.btnLoginGoogle.addEventListener("click", async () => {
-      const user = await checarSessao();
+    this.btnAbrirModal.addEventListener('click', () => this.abrirModal());
+    this.btnFecharModal.addEventListener('click', () => this.fecharModal());
+    this.modalOverlay.addEventListener('click', () => this.fecharModal());
 
-      if (user) {
-        alert("Você já está logado como: " + user.email + ". Saia antes de logar novamente.");
-        return;
-      }
+    this.formLogin.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      await this.loginComEmail();
+    });
 
+    this.btnRegistrar.addEventListener('click', async () => {
+      await this.criarConta();
+    });
+
+    this.btnLoginGoogle.addEventListener('click', async () => {
       await loginGoogle();
     });
 
-    // Botão logout
-    this.btnLogout.addEventListener("click", async () => {
+    this.btnAvatar.addEventListener('click', () => {
+      const expanded = this.btnAvatar.getAttribute('aria-expanded') === 'true';
+      this.btnAvatar.setAttribute('aria-expanded', String(!expanded));
+      this.menuDropdown.classList.toggle('hidden');
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!this.menuContainer.contains(event.target)) {
+        this.menuDropdown.classList.add('hidden');
+        this.btnAvatar.setAttribute('aria-expanded', 'false');
+      }
+    });
+
+    this.btnEditarPerfil.addEventListener('click', async () => {
+      await this.editarPerfil();
+    });
+
+    this.btnLogout.addEventListener('click', async () => {
       await logout();
+      this.menuDropdown.classList.add('hidden');
       this.atualizarUI(null);
     });
 
-    // Checar sessão inicial
-    window.addEventListener("DOMContentLoaded", async () => {
+    window.addEventListener('DOMContentLoaded', async () => {
       const user = await checarSessao();
       this.atualizarUI(user);
     });
 
-    // Escutar mudanças de sessão
     escutarMudancaSessao((user) => {
       this.atualizarUI(user);
     });
   }
 
+  abrirModal() {
+    this.modal.classList.remove('hidden');
+    this.campoEmail.focus();
+  }
+
+  fecharModal() {
+    this.modal.classList.add('hidden');
+  }
+
+  async loginComEmail() {
+    const email = this.campoEmail.value.trim();
+    const senha = this.campoSenha.value.trim();
+
+    if (!email || !senha) {
+      alert('Preencha email e senha para entrar.');
+      return;
+    }
+
+    const user = await loginEmail(email, senha);
+    if (!user) {
+      alert('Não foi possível fazer login. Verifique seus dados.');
+      return;
+    }
+
+    this.fecharModal();
+  }
+
+  async criarConta() {
+    const email = this.campoEmail.value.trim();
+    const senha = this.campoSenha.value.trim();
+
+    if (!email || !senha) {
+      alert('Preencha email e senha para criar sua conta.');
+      return;
+    }
+
+    const user = await registrarEmail(email, senha);
+    if (!user) {
+      alert('Não foi possível criar sua conta.');
+      return;
+    }
+
+    alert('Conta criada com sucesso. Verifique seu email para confirmar, se necessário.');
+  }
+
+  async editarPerfil() {
+    const user = await checarSessao();
+    if (!user) return;
+
+    const nomeAtual = user.user_metadata?.full_name || user.user_metadata?.name || '';
+    const novoNome = prompt('Digite seu nome para exibir no perfil:', nomeAtual);
+
+    if (novoNome === null) return;
+
+    const nomeTratado = novoNome.trim();
+    const atualizado = await atualizarPerfil({
+      data: { full_name: nomeTratado }
+    });
+
+    if (!atualizado) {
+      alert('Não foi possível atualizar o perfil.');
+      return;
+    }
+
+    this.atualizarUI(atualizado);
+    this.menuDropdown.classList.add('hidden');
+  }
+
   atualizarUI(user) {
     if (user) {
-      this.status.textContent = "Logado como: " + user.email;
-      this.btnLogout.style.display = "inline-block";   // mostra logout
-      this.btnLoginGoogle.style.display = "none";      // esconde login
+      this.btnAbrirModal.classList.add('hidden');
+      this.menuContainer.classList.remove('hidden');
+      this.nomeUsuario.textContent = user.user_metadata?.full_name || user.user_metadata?.name || 'Usuário';
+      this.emailUsuario.textContent = user.email || '';
+
+      const foto = user.user_metadata?.avatar_url;
+      if (foto) {
+        this.avatarImage.src = foto;
+        this.avatarImage.classList.remove('hidden');
+        this.avatarFallback.classList.add('hidden');
+      } else {
+        this.avatarImage.classList.add('hidden');
+        this.avatarFallback.classList.remove('hidden');
+        this.avatarFallback.innerHTML = DEFAULT_AVATAR;
+      }
+
+      this.fecharModal();
     } else {
-      this.status.textContent = "Nenhum usuário logado";
-      this.btnLogout.style.display = "none";           // esconde logout
-      this.btnLoginGoogle.style.display = "inline-block"; // mostra login
+      this.btnAbrirModal.classList.remove('hidden');
+      this.menuContainer.classList.add('hidden');
+      this.menuDropdown.classList.add('hidden');
+      this.btnAvatar.setAttribute('aria-expanded', 'false');
+      this.formLogin.reset();
+      this.avatarImage.removeAttribute('src');
+      this.avatarImage.classList.add('hidden');
+      this.avatarFallback.classList.remove('hidden');
+      this.avatarFallback.innerHTML = DEFAULT_AVATAR;
+      this.nomeUsuario.textContent = 'Não autenticado';
+      this.emailUsuario.textContent = 'Faça login para continuar';
     }
   }
 }

--- a/assets/js/login.js
+++ b/assets/js/login.js
@@ -34,6 +34,8 @@ export class LoginSocial {
     this.nomeUsuario = document.getElementById('nomeUsuario');
     this.emailUsuario = document.getElementById('emailUsuario');
 
+    this._unsubAuth = null;
+
     this.init();
   }
 
@@ -80,11 +82,11 @@ export class LoginSocial {
 
     this.sincronizarSessaoInicial();
 
-    escutarMudancaSessao((user) => {
+    // Mantém a UI sincronizada com mudanças de sessão (login/logout/oauth callback)
+    this._unsubAuth = escutarMudancaSessao((user) => {
       this.atualizarUI(user);
     });
   }
-
 
   async sincronizarSessaoInicial() {
     const user = await checarSessao();
@@ -142,10 +144,10 @@ export class LoginSocial {
 
     const nomeAtual = user.user_metadata?.full_name || user.user_metadata?.name || '';
     const novoNome = prompt('Digite seu nome para exibir no perfil:', nomeAtual);
-
     if (novoNome === null) return;
 
     const nomeTratado = novoNome.trim();
+
     const atualizado = await atualizarPerfil({
       data: { full_name: nomeTratado }
     });
@@ -161,12 +163,20 @@ export class LoginSocial {
 
   atualizarUI(user) {
     if (user) {
+      this.btnAbrirModal.classList.remove('inline-flex');
       this.btnAbrirModal.classList.add('hidden');
       this.menuContainer.classList.remove('hidden');
-      this.nomeUsuario.textContent = user.user_metadata?.full_name || user.user_metadata?.name || 'Usuário';
+
+      this.nomeUsuario.textContent =
+        user.user_metadata?.full_name || user.user_metadata?.name || 'Usuário';
+
       this.emailUsuario.textContent = user.email || '';
 
-      const foto = user.user_metadata?.avatar_url;
+      const foto =
+        user.user_metadata?.avatar_url ||
+        user.user_metadata?.picture ||
+        null;
+
       if (foto) {
         this.avatarImage.src = foto;
         this.avatarImage.classList.remove('hidden');
@@ -183,11 +193,13 @@ export class LoginSocial {
       this.menuContainer.classList.add('hidden');
       this.menuDropdown.classList.add('hidden');
       this.btnAvatar.setAttribute('aria-expanded', 'false');
+
       this.formLogin.reset();
       this.avatarImage.removeAttribute('src');
       this.avatarImage.classList.add('hidden');
       this.avatarFallback.classList.remove('hidden');
       this.avatarFallback.innerHTML = DEFAULT_AVATAR;
+
       this.nomeUsuario.textContent = 'Não autenticado';
       this.emailUsuario.textContent = 'Faça login para continuar';
     }

--- a/assets/js/login.js
+++ b/assets/js/login.js
@@ -78,14 +78,17 @@ export class LoginSocial {
       this.atualizarUI(null);
     });
 
-    window.addEventListener('DOMContentLoaded', async () => {
-      const user = await checarSessao();
-      this.atualizarUI(user);
-    });
+    this.sincronizarSessaoInicial();
 
     escutarMudancaSessao((user) => {
       this.atualizarUI(user);
     });
+  }
+
+
+  async sincronizarSessaoInicial() {
+    const user = await checarSessao();
+    this.atualizarUI(user);
   }
 
   abrirModal() {

--- a/assets/js/pwaRegister.js
+++ b/assets/js/pwaRegister.js
@@ -2,7 +2,47 @@ if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker
       .register('./service-worker.js')
-      .then(() => console.log('✅ Service Worker registrado com sucesso!'))
-      .catch(err => console.error('❌ Erro ao registrar o Service Worker:', err));
+      .then(reg => {
+        console.log('Service Worker registrado com sucesso!');
+
+        // Checa se já há uma versão esperando para ser ativada
+        if (reg.waiting) {
+          notifyUserOfUpdate(reg);
+        }
+
+        // Verifica se uma nova versão foi encontrada
+        reg.addEventListener('updatefound', () => {
+          const newWorker = reg.installing;
+          newWorker?.addEventListener('statechange', () => {
+            if (
+              newWorker.state === 'installed' &&
+              navigator.serviceWorker.controller
+            ) {
+              notifyUserOfUpdate(reg);
+            }
+          });
+        });
+      })
+      .catch(err =>
+        console.error('Erro ao registrar o Service Worker:', err)
+      );
   });
+}
+
+function notifyUserOfUpdate(reg) {
+  const toast = document.createElement('div');
+  toast.innerHTML = `
+  <div class="fixed bottom-2 left-4 right-4 mx-auto max-w-md  bg-green-600 text-white p-2 rounded-lg shadow-lg flex justify-between items-center z-50">
+    <span>Nova versão disponível!</span>
+    <button class="ml-4 bg-white text-green-600 px-3 py-1 rounded" id="btn-reload" >Atualizar</button>
+  </div>
+`;
+  document.body.appendChild(toast);
+
+  lucide.createIcons();
+
+  document.getElementById('btn-reload').onclick = () => {
+    reg.waiting?.postMessage({ type: 'SKIP_WAITING' });
+    window.location.reload();
+  };
 }

--- a/assets/js/sugestoes.js
+++ b/assets/js/sugestoes.js
@@ -18,7 +18,7 @@ export class Sugestoes {
       filtrados.forEach(prod => {
         const li = document.createElement('li');
         li.textContent = prod;
-        li.className = 'p-2 cursor-pointer hover:bg-gray-100';
+        li.className = 'p-2 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700';
         li.addEventListener('click', () => {
           this.input.value = prod;
           this.listaSugestoes.classList.add('hidden');

--- a/assets/js/supabase.js
+++ b/assets/js/supabase.js
@@ -1,6 +1,12 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
 const SUPABASE_URL = 'https://lqwzapmfvzpflhxnhipv.supabase.co';   // da dashboard
-const SUPABASE_ANON_KEY = 'sb_publishable_hy3jGyNIND6oIY5Wu9mNzg_ZZ2-mfUdeyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imxxd3phcG1mdnpwZmxoeG5oaXB2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzExMTQyOTMsImV4cCI6MjA4NjY5MDI5M30.MRs90nYqNgZvoq9JRbiOpa1DUkFBo9s8QWWI0YZ96Ns';        // da dashboard
+const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imxxd3phcG1mdnpwZmxoeG5oaXB2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzExMTQyOTMsImV4cCI6MjA4NjY5MDI5M30.MRs90nYqNgZvoq9JRbiOpa1DUkFBo9s8QWWI0YZ96Ns';        // da dashboard
 
-export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+    detectSessionInUrl: true
+  }
+});

--- a/index.html
+++ b/index.html
@@ -9,114 +9,207 @@
     <link rel="stylesheet" href="assets/css/style.css" />
     <script src="https://unpkg.com/lucide@latest"></script>
   </head>
+
   <body class="bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100 min-h-screen">
-    <header class="max-w-6xl mx-auto px-6 py-8 flex items-center justify-between">
+    <!-- Header -->
+    <header
+      class="max-w-6xl mx-auto px-4 sm:px-6 py-6 sm:py-8 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4"
+    >
       <div class="flex items-center gap-3">
-        <span class="inline-flex items-center justify-center w-11 h-11 rounded-2xl bg-green-600 text-white shadow-md">
-          <i data-lucide="shopping-cart" class="w-6 h-6"></i>
+        <span
+          class="inline-flex items-center justify-center w-10 h-10 sm:w-11 sm:h-11 rounded-2xl bg-green-600 text-white shadow-md"
+        >
+          <i data-lucide="shopping-cart" class="w-5 h-5 sm:w-6 sm:h-6"></i>
         </span>
-        <h1 class="text-xl font-bold leading-none">Calculadora de Compras</h1>
+        <h1 class="text-lg sm:text-xl font-bold leading-none">Calculadora de Compras</h1>
       </div>
-      <div class="flex items-center gap-3">
-        <button id="installBtnLanding" class="inline-flex items-center gap-2 bg-blue-600 hover:opacity-90 text-white font-semibold px-5 py-2.5 rounded-xl transition-all shadow-sm">
+
+      <!-- Ações -->
+      <div class="flex flex-col sm:flex-row items-stretch sm:items-center gap-3 w-full sm:w-auto">
+        <button
+          id="installBtnLanding"
+          class="inline-flex justify-center items-center gap-2 bg-blue-600 hover:opacity-90 text-white font-semibold px-5 py-3 rounded-xl transition-all shadow-sm w-full sm:w-auto"
+        >
           <i data-lucide="download" class="w-4 h-4"></i>
-          Instalar
+          <span>Instalar</span>
         </button>
-        <a href="app.html" class="inline-flex items-center gap-2 bg-green-600 hover:bg-green-700 text-white font-semibold px-5 py-2.5 rounded-xl transition-all shadow-sm">
+
+        <a
+          href="app.html"
+          class="inline-flex justify-center items-center gap-2 bg-green-600 hover:bg-green-700 text-white font-semibold px-5 py-3 rounded-xl transition-all shadow-sm w-full sm:w-auto"
+        >
           <i data-lucide="arrow-right" class="w-4 h-4"></i>
-          Abrir calculadora
+          <span>Abrir calculadora</span>
         </a>
       </div>
     </header>
 
-    <main class="max-w-6xl mx-auto px-6 pb-16 space-y-16">
-      <section class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-3xl p-8 md:p-12 shadow-sm">
-        <div class="grid md:grid-cols-2 gap-10 items-center">
+    <!-- Conteúdo -->
+    <main class="max-w-6xl mx-auto px-4 sm:px-6 pb-16 space-y-12 sm:space-y-16">
+      <!-- Hero -->
+      <section
+        class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-3xl p-6 sm:p-8 md:p-12 shadow-sm"
+      >
+        <div class="grid md:grid-cols-2 gap-8 md:gap-10 items-center">
           <div class="space-y-5">
-            <span class="inline-flex items-center gap-2 text-sm font-semibold text-green-700 dark:text-green-500 bg-green-100 dark:bg-green-900/30 px-3 py-1 rounded-full">
+            <span
+              class="inline-flex items-center gap-2 text-sm font-semibold text-green-700 dark:text-green-500 bg-green-100 dark:bg-green-900/30 px-3 py-1 rounded-full"
+            >
               <i data-lucide="sparkles" class="w-4 h-4"></i>
               Simples, rápida e feita para o dia a dia
             </span>
-            <h2 class="text-3xl md:text-4xl font-bold leading-tight">
+
+            <h2 class="text-2xl sm:text-3xl md:text-4xl font-bold leading-tight">
               Tenha controle do carrinho antes de chegar no caixa.
             </h2>
-            <p class="text-gray-600 dark:text-gray-300 text-lg">
-              A Calculadora de Compras ajuda você a registrar produtos e acompanhar o total em tempo real, evitando surpresas no mercado.
+
+            <p class="text-gray-600 dark:text-gray-300 text-base sm:text-lg">
+              A Calculadora de Compras ajuda você a registrar produtos e acompanhar o total em tempo real, evitando
+              surpresas no mercado.
             </p>
-            <div class="flex flex-wrap gap-3">
-              <a href="app.html" class="bg-green-600 hover:bg-green-700 text-white font-semibold px-6 py-3 rounded-xl transition-all">Começar agora</a>
-              <a href="#roadmap" class="border border-gray-300 dark:border-gray-600 hover:border-green-600 font-semibold px-6 py-3 rounded-xl transition-all">Ver roadmap</a>
+
+            <div class="flex flex-col sm:flex-row flex-wrap gap-3">
+              <a
+                href="app.html"
+                class="w-full sm:w-auto text-center bg-green-600 hover:bg-green-700 text-white font-semibold px-6 py-3 rounded-xl transition-all"
+              >
+                Começar agora
+              </a>
+
+              <a
+                href="#roadmap"
+                class="w-full sm:w-auto text-center border border-gray-300 dark:border-gray-600 hover:border-green-600 font-semibold px-6 py-3 rounded-xl transition-all"
+              >
+                Ver roadmap
+              </a>
             </div>
           </div>
-          <div class="bg-gradient-to-br from-green-600 to-blue-600 rounded-3xl p-8 text-white shadow-xl">
-            <h3 class="text-xl font-bold mb-5">O que você consegue fazer</h3>
+
+          <div class="bg-gradient-to-br from-green-600 to-blue-600 rounded-3xl p-6 sm:p-8 text-white shadow-xl">
+            <h3 class="text-lg sm:text-xl font-bold mb-5">O que você consegue fazer</h3>
             <ul class="space-y-4 text-white/95">
-              <li class="flex items-start gap-3"><i data-lucide="check-circle-2" class="w-5 h-5 mt-0.5"></i>Adicionar itens rapidamente durante as compras.</li>
-              <li class="flex items-start gap-3"><i data-lucide="check-circle-2" class="w-5 h-5 mt-0.5"></i>Visualizar quantidade e valor total instantaneamente.</li>
-              <li class="flex items-start gap-3"><i data-lucide="check-circle-2" class="w-5 h-5 mt-0.5"></i>Usar no celular como app instalado com suporte PWA.</li>
+              <li class="flex items-start gap-3">
+                <i data-lucide="check-circle-2" class="w-5 h-5 mt-0.5"></i>
+                <span>Adicionar itens rapidamente durante as compras.</span>
+              </li>
+              <li class="flex items-start gap-3">
+                <i data-lucide="check-circle-2" class="w-5 h-5 mt-0.5"></i>
+                <span>Visualizar quantidade e valor total instantaneamente.</span>
+              </li>
+              <li class="flex items-start gap-3">
+                <i data-lucide="check-circle-2" class="w-5 h-5 mt-0.5"></i>
+                <span>Usar no celular como app instalado com suporte PWA.</span>
+              </li>
             </ul>
           </div>
         </div>
       </section>
 
+      <!-- Features -->
       <section>
         <div class="mb-6">
-          <h2 class="text-2xl md:text-3xl font-bold">Funções da calculadora</h2>
-          <p class="text-gray-600 dark:text-gray-300 mt-2">Tudo foi pensado para ser direto e eficiente enquanto você compra.</p>
+          <h2 class="text-xl sm:text-2xl md:text-3xl font-bold">Funções da calculadora</h2>
+          <p class="text-gray-600 dark:text-gray-300 mt-2">
+            Tudo foi pensado para ser direto e eficiente enquanto você compra.
+          </p>
         </div>
+
         <div class="grid md:grid-cols-3 gap-4">
-          <article class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-6 space-y-3">
+          <article
+            class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-6 space-y-3"
+          >
             <i data-lucide="plus-circle" class="w-8 h-8 text-green-600"></i>
             <h3 class="font-semibold text-lg">Cadastro rápido de produtos</h3>
             <p class="text-gray-600 dark:text-gray-300">Adicione nome e valor de cada item em poucos toques.</p>
           </article>
-          <article class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-6 space-y-3">
+
+          <article
+            class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-6 space-y-3"
+          >
             <i data-lucide="calculator" class="w-8 h-8 text-blue-600"></i>
             <h3 class="font-semibold text-lg">Total em tempo real</h3>
             <p class="text-gray-600 dark:text-gray-300">Acompanhe automaticamente quanto já foi gasto no carrinho.</p>
           </article>
-          <article class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-6 space-y-3">
+
+          <article
+            class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-6 space-y-3"
+          >
             <i data-lucide="sun-moon" class="w-8 h-8 text-gray-600"></i>
             <h3 class="font-semibold text-lg">Tema claro e escuro</h3>
-            <p class="text-gray-600 dark:text-gray-300">Use do jeito que preferir, com visual limpo em qualquer ambiente.</p>
+            <p class="text-gray-600 dark:text-gray-300">
+              Use do jeito que preferir, com visual limpo em qualquer ambiente.
+            </p>
           </article>
         </div>
       </section>
 
-      <section id="roadmap" class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-3xl p-8 md:p-10">
-        <h2 class="text-2xl md:text-3xl font-bold mb-2">Roadmap de evolução</h2>
-        <p class="text-gray-600 dark:text-gray-300 mb-8">Próximos passos planejados para deixar a calculadora ainda mais completa.</p>
+      <!-- Roadmap -->
+      <section
+        id="roadmap"
+        class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-3xl p-6 sm:p-8 md:p-10"
+      >
+        <h2 class="text-xl sm:text-2xl md:text-3xl font-bold mb-2">Roadmap de evolução</h2>
+        <p class="text-gray-600 dark:text-gray-300 mb-8">
+          Próximos passos planejados para deixar a calculadora ainda mais completa.
+        </p>
+
         <div class="space-y-4">
-          <div class="flex items-start gap-4 p-4 rounded-xl bg-gray-50 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-700">
-            <span class="w-8 h-8 rounded-full bg-green-600 text-white text-sm font-bold flex items-center justify-center">1</span>
+          <div
+            class="flex items-start gap-4 p-4 rounded-xl bg-gray-50 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-700"
+          >
+            <span class="w-8 h-8 rounded-full bg-green-600 text-white text-sm font-bold flex items-center justify-center"
+              >1</span
+            >
             <div>
               <h3 class="font-semibold">Edição de produtos já adicionados</h3>
-              <p class="text-gray-600 dark:text-gray-300">Ajustar valores e nomes sem precisar remover e cadastrar novamente.</p>
+              <p class="text-gray-600 dark:text-gray-300">
+                Ajustar valores e nomes sem precisar remover e cadastrar novamente.
+              </p>
             </div>
           </div>
-          <div class="flex items-start gap-4 p-4 rounded-xl bg-gray-50 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-700">
-            <span class="w-8 h-8 rounded-full bg-blue-600 text-white text-sm font-bold flex items-center justify-center">2</span>
+
+          <div
+            class="flex items-start gap-4 p-4 rounded-xl bg-gray-50 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-700"
+          >
+            <span class="w-8 h-8 rounded-full bg-blue-600 text-white text-sm font-bold flex items-center justify-center"
+              >2</span
+            >
             <div>
               <h3 class="font-semibold">Listas salvas por mercado ou ocasião</h3>
-              <p class="text-gray-600 dark:text-gray-300">Criar listas reutilizáveis para compras semanais, mensais ou especiais.</p>
+              <p class="text-gray-600 dark:text-gray-300">
+                Criar listas reutilizáveis para compras semanais, mensais ou especiais.
+              </p>
             </div>
           </div>
-          <div class="flex items-start gap-4 p-4 rounded-xl bg-gray-50 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-700">
-            <span class="w-8 h-8 rounded-full bg-gray-700 text-white text-sm font-bold flex items-center justify-center">3</span>
+
+          <div
+            class="flex items-start gap-4 p-4 rounded-xl bg-gray-50 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-700"
+          >
+            <span
+              class="w-8 h-8 rounded-full bg-gray-700 text-white text-sm font-bold flex items-center justify-center"
+              >3</span
+            >
             <div>
               <h3 class="font-semibold">Relatórios simples de gastos</h3>
-              <p class="text-gray-600 dark:text-gray-300">Visualizar histórico e médias para melhorar o planejamento do orçamento.</p>
+              <p class="text-gray-600 dark:text-gray-300">
+                Visualizar histórico e médias para melhorar o planejamento do orçamento.
+              </p>
             </div>
           </div>
         </div>
       </section>
     </main>
 
+    <!-- Footer -->
     <footer class="py-6 px-6 text-center text-sm text-gray-500 dark:text-gray-400">
-     2026 Calculadora Preço
+      2026 Calculadora Preço
     </footer>
 
-    <button id="btn-tema" class="fixed top-6 right-4 p-2 rounded-full shadow bg-white dark:bg-gray-800 text-gray-800 dark:text-white transition-colors">
+    <!-- Botão tema (no mobile fica embaixo, no desktop no topo) -->
+    <button
+      id="btn-tema"
+      class="fixed bottom-6 right-4 sm:top-6 sm:bottom-auto p-2 rounded-full shadow bg-white dark:bg-gray-800 text-gray-800 dark:text-white transition-colors z-50"
+    >
       <i data-lucide="moon" id="icone-tema"></i>
     </button>
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -2,23 +2,35 @@ const CACHE_NAME = 'compras-cache-v1';
 const urlsToCache = [
   './',
   './index.html',
-  './assets/js/script.js',
+  './assets/js/main.js',
   './assets/css/style.css',
   './manifest.json',
   './assets/icon/icon-192.png',
   './assets/icon/icon-512.png'
 ];
 
+// Instala o SW e adiciona ao cache
 self.addEventListener('install', event => {
   event.waitUntil(
-    caches.open(CACHE_NAME)
-      .then(cache => cache.addAll(urlsToCache))
+    caches.open(CACHE_NAME).then(cache => cache.addAll(urlsToCache))
   );
 });
 
+// Ativa o novo SW imediatamente para controlar as páginas
+self.addEventListener('activate', event => {
+  event.waitUntil(clients.claim());
+});
+
+// Intercepta requisições e retorna do cache ou faz fetch
 self.addEventListener('fetch', event => {
   event.respondWith(
-    caches.match(event.request)
-      .then(resp => resp || fetch(event.request))
+    caches.match(event.request).then(resp => resp || fetch(event.request))
   );
+});
+
+// Escuta por mensagens do tipo SKIP_WAITING
+self.addEventListener('message', event => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
 });

--- a/supabase_profiles_schema.sql
+++ b/supabase_profiles_schema.sql
@@ -34,21 +34,27 @@ security definer
 set search_path = public
 as $$
 begin
-  insert into public.profiles (id, email, full_name, avatar_url, provider)
-  values (
-    new.id,
-    new.email,
-    coalesce(new.raw_user_meta_data->>'full_name', new.raw_user_meta_data->>'name'),
-    new.raw_user_meta_data->>'avatar_url',
-    new.app_metadata->>'provider'
-  )
-  on conflict (id) do update
-  set
-    email = excluded.email,
-    full_name = coalesce(excluded.full_name, public.profiles.full_name),
-    avatar_url = coalesce(excluded.avatar_url, public.profiles.avatar_url),
-    provider = coalesce(excluded.provider, public.profiles.provider),
-    updated_at = now();
+  begin
+    insert into public.profiles (id, email, full_name, avatar_url, provider)
+    values (
+      new.id,
+      new.email,
+      coalesce(new.raw_user_meta_data->>'full_name', new.raw_user_meta_data->>'name'),
+      new.raw_user_meta_data->>'avatar_url',
+      new.app_metadata->>'provider'
+    )
+    on conflict (id) do update
+    set
+      email = excluded.email,
+      full_name = coalesce(excluded.full_name, public.profiles.full_name),
+      avatar_url = coalesce(excluded.avatar_url, public.profiles.avatar_url),
+      provider = coalesce(excluded.provider, public.profiles.provider),
+      updated_at = now();
+  exception
+    when others then
+      -- Nunca bloquear a criação do usuário no Auth por erro de perfil.
+      raise warning 'Falha ao sincronizar perfil do usuário %: %', new.id, sqlerrm;
+  end;
 
   return new;
 end;

--- a/supabase_profiles_schema.sql
+++ b/supabase_profiles_schema.sql
@@ -1,0 +1,82 @@
+-- Execute este script no SQL Editor do Supabase
+-- Objetivo: criar tabela de perfil de usuário vinculada ao auth.users
+
+create table if not exists public.profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  email text,
+  full_name text,
+  avatar_url text,
+  provider text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create or replace function public.handle_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists set_profiles_updated_at on public.profiles;
+create trigger set_profiles_updated_at
+before update on public.profiles
+for each row execute function public.handle_updated_at();
+
+-- Cria/atualiza perfil automaticamente quando usuário é criado no auth
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.profiles (id, email, full_name, avatar_url, provider)
+  values (
+    new.id,
+    new.email,
+    coalesce(new.raw_user_meta_data->>'full_name', new.raw_user_meta_data->>'name'),
+    new.raw_user_meta_data->>'avatar_url',
+    new.app_metadata->>'provider'
+  )
+  on conflict (id) do update
+  set
+    email = excluded.email,
+    full_name = coalesce(excluded.full_name, public.profiles.full_name),
+    avatar_url = coalesce(excluded.avatar_url, public.profiles.avatar_url),
+    provider = coalesce(excluded.provider, public.profiles.provider),
+    updated_at = now();
+
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+after insert on auth.users
+for each row execute function public.handle_new_user();
+
+alter table public.profiles enable row level security;
+
+-- Usuário autenticado só acessa o próprio perfil
+drop policy if exists "profiles_select_own" on public.profiles;
+create policy "profiles_select_own"
+on public.profiles
+for select
+using (auth.uid() = id);
+
+drop policy if exists "profiles_insert_own" on public.profiles;
+create policy "profiles_insert_own"
+on public.profiles
+for insert
+with check (auth.uid() = id);
+
+drop policy if exists "profiles_update_own" on public.profiles;
+create policy "profiles_update_own"
+on public.profiles
+for update
+using (auth.uid() = id)
+with check (auth.uid() = id);


### PR DESCRIPTION
### Motivation
- Corrigir fluxo de OAuth para que, após autenticar com Google, o usuário volte para a própria calculadora em vez da landing page. 
- Melhorar a experiência de autenticação com um único ponto de entrada (botão `Login`) e um modal central com opções claras (email/senha, criar conta, login Google). 
- Exibir avatar do usuário quando autenticado e oferecer ações de perfil (editar nome) e logout no próprio app. 

### Description
- Atualizei `assets/js/auth.js` para usar um `redirectTo` dinâmico apontando para `app.html` e adicionei a função `atualizarPerfil` que chama `supabase.auth.updateUser`. 
- Reestruturei a área de autenticação em `app.html` para substituir o bloco antigo por um único botão `Login`, um modal central (`#loginModal`) com formulário (`#loginForm`), botão `Criar nova conta` e `Entrar com Google`, além do container do menu de usuário com avatar e dropdown (`#userMenuContainer`, `#userDropdown`). 
- Substituí e refatorei a lógica em `assets/js/login.js` (nova versão) para controlar o modal, login via email (`loginEmail`), registro (`registrarEmail`), login Google (`loginGoogle`), escuta de sessão (`escutarMudancaSessao`), atualização de perfil (`atualizarPerfil`) e o menu/avatar (fallback SVG quando não há foto). 
- Regerei `assets/css/style.css` (Tailwind) para incluir classes utilitárias usadas pelo novo layout. 

### Testing
- Executei o build do CSS com `npx @tailwindcss/cli -i ./assets/css/style-input.css -o ./assets/css/style.css` e a execução terminou com sucesso. 
- Subi um servidor simples com `python3 -m http.server 4173` para validação visual local e a página carregou sem erros HTTP relevantes. 
- Rodei um script Playwright que abre `http://127.0.0.1:4173/app.html`, clica em `#btnAbrirLoginModal` e capturou um screenshot do modal aberto, validando visualmente a nova interface.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999dde1ad7c8324ba4151474b316fc4)